### PR TITLE
Add --merge and --prefix options for multi-machine archive management

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Options:
 - `--dry-run` - show what would be converted without creating files
 - `--open` - open the generated archive in your default browser
 - `-q, --quiet` - suppress all output except errors
+- `-m, --merge` - merge with existing archive (preserve orphan sessions)
+- `--prefix NAME` - prefix for sessions in index (e.g., machine name)
 
 Examples:
 
@@ -191,6 +193,28 @@ claude-code-transcripts all -o ./my-archive
 # Include agent sessions
 claude-code-transcripts all --include-agents
 ```
+
+### Merging archives from multiple machines
+
+Use `-m`/`--merge` to combine sessions from different machines into a single archive:
+
+```bash
+# Machine A: create initial archive
+claude-code-transcripts all -o /shared/archive
+
+# Machine B: merge additional sessions
+claude-code-transcripts all -o /shared/archive -m
+
+# With prefix (shown in index)
+claude-code-transcripts all -o /shared/archive --merge --prefix=laptop
+```
+
+The `--merge` option:
+- Regenerates all sessions found in the source directory
+- Preserves "orphan" sessions in the archive that are no longer in the source
+- Useful for maintaining a unified archive from multiple machines
+
+The `--prefix` option adds a label to sessions in the index, helping identify which machine they came from.
 
 ## Development
 

--- a/src/claude_code_transcripts/templates/project_index.html
+++ b/src/claude_code_transcripts/templates/project_index.html
@@ -10,7 +10,7 @@
         <div class="index-item">
             <a href="{{ session.name }}/index.html">
                 <div class="index-item-header">
-                    <span class="index-item-number">{{ session.date }}</span>
+                    <span class="index-item-number">{% if session.prefix %}<span style="color: var(--tool-border); font-weight: 600;">[{{ session.prefix }}]</span> {% endif %}{{ session.date }}</span>
                     <span style="color: var(--text-muted);">{{ "%.0f"|format(session.size_kb) }} KB</span>
                 </div>
                 <div class="index-item-content">


### PR DESCRIPTION
## Summary

This PR adds two new options to the `all` command to support managing transcript archives across multiple machines:

- **`--merge` / `-m`**: Preserves existing sessions in the output directory when regenerating. Sessions from the source are regenerated, while sessions only present in the existing archive are kept in the index.

- **`--prefix`**: Adds a prefix label to sessions (displayed as `[prefix]` in the index). Useful for identifying which machine generated each session.

## Use case

When using Claude Code on multiple machines, each machine has its own `~/.claude/projects/` folder. Without `--merge`, regenerating the archive from one machine would overwrite sessions from other machines.

With these options, you can:
```bash
# On machine A
claude-code-transcripts all --merge --prefix=laptop -o /shared/archive/

# On machine B  
claude-code-transcripts all --merge --prefix=desktop -o /shared/archive/
```

Each run preserves sessions from other machines while regenerating local sessions with a machine identifier.

## Changes

- Added `find_existing_sessions()` function to parse existing archive's project_index.html
- Added `merge_sessions()` function to combine source and existing sessions
- Modified `generate_batch_html()` to support merge and prefix parameters
- Updated project_index.html template to display prefix labels
- Added comprehensive tests for all new functionality
- Updated README.md with documentation

## Test plan

- [x] Unit tests pass (`uv run pytest`)
- [x] Manual testing with real session files
- [x] Verified prefix display in generated HTML
- [x] Verified merge preserves orphaned sessions