### PR TITLE
Add nice rendering for some slash commands in transcripts

### DIFF
--- a/src/claude_code_transcripts/templates/macros.html
+++ b/src/claude_code_transcripts/templates/macros.html
@@ -185,3 +185,11 @@
 {% macro index_long_text(rendered_content) %}
 <div class="index-item-long-text"><div class="truncatable"><div class="truncatable-content"><div class="index-item-long-text-content">{{ rendered_content|safe }}</div></div><button class="expand-btn">Show more</button></div></div>
 {%- endmacro %}
+
+{# Slash command with expandable output - output contains HTML from ANSI conversion #}
+{% macro slash_command(name, output) %}
+<details class="slash-command">
+<summary class="slash-command-summary"><span class="slash-command-icon">&#x25B6;</span> <span class="slash-command-name">{{ name }}</span></summary>
+<pre class="slash-command-output">{{ output|safe }}</pre>
+</details>
+{%- endmacro %}

--- a/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_index_html.html
+++ b/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_index_html.html
@@ -140,6 +140,14 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
 .search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
 .search-result-content { padding: 12px; }
 .search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+.slash-command { margin: 8px 0; }
+.slash-command-summary { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 6px; font-family: monospace; cursor: pointer; list-style: none; }
+.slash-command-summary::-webkit-details-marker { display: none; }
+.slash-command-summary:hover { background: #e1bee7; }
+.slash-command-icon { color: var(--tool-border); }
+.slash-command-name { font-weight: 600; color: var(--tool-border); }
+.slash-command-output { margin: 8px 0 0 0; font-size: 0.85rem; max-height: 400px; overflow-y: auto; }
+.ctx-icon { display: inline-block; width: 1.2em; text-align: center; }
 @media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
 </style>
 </head>

--- a/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_001_html.html
+++ b/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_001_html.html
@@ -140,6 +140,14 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
 .search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
 .search-result-content { padding: 12px; }
 .search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+.slash-command { margin: 8px 0; }
+.slash-command-summary { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 6px; font-family: monospace; cursor: pointer; list-style: none; }
+.slash-command-summary::-webkit-details-marker { display: none; }
+.slash-command-summary:hover { background: #e1bee7; }
+.slash-command-icon { color: var(--tool-border); }
+.slash-command-name { font-weight: 600; color: var(--tool-border); }
+.slash-command-output { margin: 8px 0 0 0; font-size: 0.85rem; max-height: 400px; overflow-y: auto; }
+.ctx-icon { display: inline-block; width: 1.2em; text-align: center; }
 @media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
 </style>
 </head>

--- a/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_002_html.html
+++ b/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_002_html.html
@@ -140,6 +140,14 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
 .search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
 .search-result-content { padding: 12px; }
 .search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+.slash-command { margin: 8px 0; }
+.slash-command-summary { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 6px; font-family: monospace; cursor: pointer; list-style: none; }
+.slash-command-summary::-webkit-details-marker { display: none; }
+.slash-command-summary:hover { background: #e1bee7; }
+.slash-command-icon { color: var(--tool-border); }
+.slash-command-name { font-weight: 600; color: var(--tool-border); }
+.slash-command-output { margin: 8px 0 0 0; font-size: 0.85rem; max-height: 400px; overflow-y: auto; }
+.ctx-icon { display: inline-block; width: 1.2em; text-align: center; }
 @media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
 </style>
 </head>

--- a/tests/__snapshots__/test_generate_html/TestParseSessionFile.test_jsonl_generates_html.html
+++ b/tests/__snapshots__/test_generate_html/TestParseSessionFile.test_jsonl_generates_html.html
@@ -140,6 +140,14 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
 .search-result-page { padding: 6px 12px; background: rgba(0,0,0,0.03); font-size: 0.8rem; color: var(--text-muted); border-bottom: 1px solid rgba(0,0,0,0.06); }
 .search-result-content { padding: 12px; }
 .search-result mark { background: #fff59d; padding: 1px 2px; border-radius: 2px; }
+.slash-command { margin: 8px 0; }
+.slash-command-summary { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; background: var(--tool-bg); border: 1px solid var(--tool-border); border-radius: 6px; font-family: monospace; cursor: pointer; list-style: none; }
+.slash-command-summary::-webkit-details-marker { display: none; }
+.slash-command-summary:hover { background: #e1bee7; }
+.slash-command-icon { color: var(--tool-border); }
+.slash-command-name { font-weight: 600; color: var(--tool-border); }
+.slash-command-output { margin: 8px 0 0 0; font-size: 0.85rem; max-height: 400px; overflow-y: auto; }
+.ctx-icon { display: inline-block; width: 1.2em; text-align: center; }
 @media (max-width: 600px) { body { padding: 8px; } .message, .index-item { border-radius: 8px; } .message-content, .index-item-content { padding: 12px; } pre { font-size: 0.8rem; padding: 8px; } #search-box input { width: 120px; } #search-modal[open] { width: 95vw; height: 90vh; } }
 </style>
 </head>

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -27,6 +27,11 @@ from claude_code_transcripts import (
     parse_session_file,
     get_session_summary,
     find_local_sessions,
+    ansi_to_html,
+    is_slash_command_message,
+    parse_slash_command,
+    is_command_stdout_message,
+    extract_command_stdout,
 )
 
 
@@ -1537,3 +1542,119 @@ class TestSearchFeature:
 
         # Total pages should be embedded for JS to know how many pages to fetch
         assert "totalPages" in index_html or "total_pages" in index_html
+
+
+class TestSlashCommandDetection:
+    """Tests for slash command detection functions."""
+
+    def test_detects_command_message(self):
+        """Test detecting a slash command message."""
+        content = "<command-name>/context</command-name>\n<command-message>context</command-message>\n<command-args></command-args>"
+        assert is_slash_command_message(content) is True
+
+    def test_rejects_normal_message(self):
+        """Test rejecting normal user messages."""
+        assert is_slash_command_message("Hello world") is False
+
+    def test_rejects_non_string(self):
+        """Test rejecting non-string content."""
+        assert is_slash_command_message(None) is False
+        assert is_slash_command_message(123) is False
+        assert is_slash_command_message([]) is False
+
+    def test_parses_command_name(self):
+        """Test parsing command name from message."""
+        content = "<command-name>/context</command-name>\n<command-message>context</command-message>\n<command-args></command-args>"
+        assert parse_slash_command(content) == "/context"
+
+    def test_parses_command_with_args(self):
+        """Test parsing command with arguments."""
+        content = "<command-name>/model</command-name>\n<command-message>model</command-message>\n<command-args>opus</command-args>"
+        assert parse_slash_command(content) == "/model"
+
+    def test_parse_returns_none_for_non_command(self):
+        """Test parse returns None for non-command content."""
+        assert parse_slash_command("Hello world") is None
+
+
+class TestCommandStdout:
+    """Tests for command stdout detection and extraction."""
+
+    def test_detects_stdout_message(self):
+        """Test detecting command stdout message."""
+        content = "<local-command-stdout>Output here</local-command-stdout>"
+        assert is_command_stdout_message(content) is True
+
+    def test_rejects_normal_message(self):
+        """Test rejecting normal messages."""
+        assert is_command_stdout_message("Hello world") is False
+
+    def test_rejects_non_string(self):
+        """Test rejecting non-string content."""
+        assert is_command_stdout_message(None) is False
+
+    def test_extracts_and_cleans_stdout(self):
+        """Test extracting and cleaning stdout content."""
+        content = "<local-command-stdout>\x1b[1mContext Usage\x1b[22m: 50%</local-command-stdout>"
+        result = extract_command_stdout(content)
+        # Now returns HTML with bold tags
+        assert result == "<strong>Context Usage</strong>: 50%"
+
+    def test_extracts_multiline_stdout(self):
+        """Test extracting multiline stdout."""
+        content = "<local-command-stdout>Line 1\nLine 2\nLine 3</local-command-stdout>"
+        result = extract_command_stdout(content)
+        assert result == "Line 1\nLine 2\nLine 3"
+
+    def test_wraps_context_icons_in_fixed_width_spans(self):
+        """Test that context icons get wrapped in fixed-width spans for grid alignment."""
+        content = "<local-command-stdout>\x1b[38;5;135m⛁ ⛁ \x1b[38;5;246m⛶ ⛶\x1b[39m</local-command-stdout>"
+        result = extract_command_stdout(content)
+        # Icons should be wrapped in ctx-icon spans with colors
+        assert '<span class="ctx-icon">⛁</span>' in result
+        assert '<span class="ctx-icon">⛶</span>' in result
+        assert 'style="color:#af5fd7"' in result  # purple for 135
+        assert 'style="color:#949494"' in result  # gray for 246
+
+
+class TestAnsiToHtml:
+    """Tests for ANSI to HTML conversion edge cases."""
+
+    def test_unclosed_bold_gets_closed(self):
+        """Test that unclosed bold tags are automatically closed."""
+        text = "\x1b[1mBold text without close"
+        result = ansi_to_html(text)
+        assert result == "<strong>Bold text without close</strong>"
+
+    def test_nested_bold_not_duplicated(self):
+        """Test that nested bold codes don't create duplicate tags."""
+        text = "\x1b[1m\x1b[1mDouble bold\x1b[22m"
+        result = ansi_to_html(text)
+        assert result == "<strong>Double bold</strong>"
+
+    def test_extra_close_bold_ignored(self):
+        """Test that extra close bold codes are ignored."""
+        text = "Normal\x1b[22m text"
+        result = ansi_to_html(text)
+        assert result == "Normal text"
+
+    def test_reset_closes_both_color_and_bold(self):
+        """Test that reset code closes both color and bold."""
+        text = "\x1b[1m\x1b[38;5;135mBold purple\x1b[0m normal"
+        result = ansi_to_html(text)
+        assert (
+            result
+            == '<strong><span style="color:#af5fd7">Bold purple</span></strong> normal'
+        )
+
+    def test_unclosed_color_gets_closed(self):
+        """Test that unclosed color spans are automatically closed."""
+        text = "\x1b[38;5;244mGray text"
+        result = ansi_to_html(text)
+        assert result == '<span style="color:#808080">Gray text</span>'
+
+    def test_html_entities_escaped(self):
+        """Test that HTML special characters are escaped."""
+        text = "<script>alert('xss')</script> & more"
+        result = ansi_to_html(text)
+        assert result == "&lt;script&gt;alert('xss')&lt;/script&gt; &amp; more"


### PR DESCRIPTION
Amazing tool, thanks.

This is to handle output from some of the slash commands that use terminal ANSI markup, for example /context which I frequently use. Implementation by Claude.

  - Detect slash command messages (<command-name>/context</command-name>) and merge with their stdout output
  - Convert ANSI terminal colors to HTML spans with proper colors
  - Render as expandable "details", widget styled like other tools
  - Skip slash commands from index timeline (they're meta, not prompts)