### PR TITLE
Gemini cli support and no pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Tests](https://github.com/simonw/claude-code-transcripts/workflows/Test/badge.svg)](https://github.com/simonw/claude-code-transcripts/actions?query=workflow%3ATest)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/simonw/claude-code-transcripts/blob/main/LICENSE)
 
-Convert Claude Code session files (JSON or JSONL) to clean, mobile-friendly HTML pages with pagination.
+Convert Claude Code and Gemini session files (JSON or JSONL) to clean, mobile-friendly HTML pages.
 
 [Example transcript](https://static.simonwillison.net/static/2025/claude-code-microjs/index.html) produced using this tool.
 
@@ -24,11 +24,11 @@ uvx claude-code-transcripts --help
 
 ## Usage
 
-This tool converts Claude Code session files into browseable multi-page HTML transcripts.
+This tool converts Claude Code and Gemini session files into browseable HTML transcripts.
 
 There are four commands available:
 
-- `local` (default) - select from local Claude Code sessions stored in `~/.claude/projects`
+- `local` (default) - select from local sessions stored in `~/.claude/projects` and `~/.gemini/tmp/*/chats`
 - `web` - select from web sessions via the Claude API
 - `json` - convert a specific JSON or JSONL session file
 - `all` - convert all local sessions to a browsable HTML archive
@@ -58,7 +58,7 @@ The generated output includes:
 
 ### Local sessions
 
-Local Claude Code sessions are stored as JSONL files in `~/.claude/projects`. Run with no arguments to select from recent sessions:
+Local sessions are stored as JSONL files in `~/.claude/projects` (Claude Code) and JSON files in `~/.gemini/tmp/*/chats` (Gemini). Run with no arguments to select from recent sessions:
 
 ```bash
 claude-code-transcripts
@@ -153,6 +153,8 @@ claude-code-transcripts json session.jsonl --open
 ```
 
 When using [Claude Code for web](https://claude.ai/code) you can export your session as a `session.json` file using the `teleport` command.
+
+Gemini sessions are stored locally under `~/.gemini/tmp/*/chats`. You can convert any of those JSON files using the `json` command.
 
 ### Converting all sessions
 

--- a/src/claude_code_transcripts/templates/base.html
+++ b/src/claude_code_transcripts/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}Claude Code transcript{% endblock %}</title>
+    <title>{% block title %}{{ transcript_title }}{% endblock %}</title>
     <style>{{ css|safe }}</style>
 </head>
 <body>

--- a/src/claude_code_transcripts/templates/index.html
+++ b/src/claude_code_transcripts/templates/index.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Claude Code transcript - Index{% endblock %}
+{% block title %}{{ transcript_title }} - Index{% endblock %}
 
 {% block content %}
         <div class="header-row">
-            <h1>Claude Code transcript</h1>
+            <h1>{{ transcript_title }}</h1>
             <div id="search-box">
                 <input type="text" id="search-input" placeholder="Search..." aria-label="Search transcripts">
                 <button id="search-btn" type="button" aria-label="Search">

--- a/src/claude_code_transcripts/templates/page.html
+++ b/src/claude_code_transcripts/templates/page.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}Claude Code transcript - page {{ page_num }}{% endblock %}
+{% block title %}{{ transcript_title }} - page {{ page_num }}{% endblock %}
 
 {% block content %}
-        <h1><a href="index.html" style="color: inherit; text-decoration: none;">Claude Code transcript</a> - page {{ page_num }}/{{ total_pages }}</h1>
+        <h1><a href="index.html" style="color: inherit; text-decoration: none;">{{ transcript_title }}</a> - page {{ page_num }}/{{ total_pages }}</h1>
         {{ pagination_html|safe }}
         {{ messages_html|safe }}
         {{ pagination_html|safe }}


### PR DESCRIPTION
_(Note: This mixes two different things, if it's a problem and you think one or both of them is worth merging I can break it out into two different PR's)._

First, it adds support for generating transcripts for gemini. When prompting you to select a session it will list them together and prefix gemini sessions with [gem] and claude with [cld].

The second thing it does it make pagination optional and defaults to one big file. Browsers and computers are really fast nowadays and will have [no problem rendering big files](https://www.zachleat.com/twitter/1169998370041208832/) so personally I don't see any value in paginating it. As a bonus it allows searching using the native search (though I see you already solved that).