### PR TITLE
Display the custom title (from /rename) in the session picker

### DIFF
--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -1076,6 +1076,26 @@ class TestGetSessionSummary:
         assert len(summary) <= 100
         assert summary.endswith("...")
 
+    def test_gets_custom_title_from_jsonl(self, tmp_path):
+        """Test extracting custom title from JSONL file (set via /rename)."""
+        jsonl_file = tmp_path / "test.jsonl"
+        jsonl_file.write_text(
+            '{"type":"custom-title","customTitle":"GIT stuff","sessionId":"abc123"}\n'
+            '{"type":"user","message":{"content":"Hello"}}\n'
+        )
+        summary = get_session_summary(jsonl_file)
+        assert summary == "GIT stuff"
+
+    def test_custom_title_takes_priority_over_summary(self, tmp_path):
+        """Test that custom title takes priority over summary entry."""
+        jsonl_file = tmp_path / "test.jsonl"
+        jsonl_file.write_text(
+            '{"type":"custom-title","customTitle":"My Custom Title","sessionId":"abc123"}\n'
+            '{"type":"summary","summary":"Auto-generated summary"}\n'
+        )
+        summary = get_session_summary(jsonl_file)
+        assert summary == "My Custom Title"
+
 
 class TestFindLocalSessions:
     """Tests for find_local_sessions which discovers local JSONL files."""


### PR DESCRIPTION
## Summary

  Sessions renamed via `/rename` now display the custom title in the session picker instead of the auto-generated summary.

  Previously, `_get_jsonl_summary()` only checked for:
  1. `type: "summary"` entries
  2. First user message (fallback)

  Now it first checks for `type: "custom-title"` entries, which are created when users rename a session with `/rename`:

  ```json
  {"type":"custom-title","customTitle":"GIT stuff","sessionId":"abc123"}

  Changes

  - Modified _get_jsonl_summary() in src/claude_code_transcripts/__init__.py to check for custom-title first
  - Added two tests in tests/test_generate_html.py

  Test plan

  - Added test_gets_custom_title_from_jsonl
  - Added test_custom_title_takes_priority_over_summary
  - All 106 existing tests pass