### PR TITLE
Add URL support to code transcripts command

### DIFF
--- a/src/claude_code_transcripts/__init__.py
+++ b/src/claude_code_transcripts/__init__.py
@@ -1452,8 +1452,47 @@ def local_cmd(output, output_auto, repo, gist, include_json, open_browser, limit
         webbrowser.open(index_url)
 
 
+def is_url(path):
+    """Check if a path is a URL (starts with http:// or https://)."""
+    return path.startswith("http://") or path.startswith("https://")
+
+
+def fetch_url_to_tempfile(url):
+    """Fetch a URL and save to a temporary file.
+
+    Returns the Path to the temporary file.
+    Raises click.ClickException on network errors.
+    """
+    try:
+        response = httpx.get(url, timeout=60.0, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.RequestError as e:
+        raise click.ClickException(f"Failed to fetch URL: {e}")
+    except httpx.HTTPStatusError as e:
+        raise click.ClickException(
+            f"Failed to fetch URL: {e.response.status_code} {e.response.reason_phrase}"
+        )
+
+    # Determine file extension from URL
+    url_path = url.split("?")[0]  # Remove query params
+    if url_path.endswith(".jsonl"):
+        suffix = ".jsonl"
+    elif url_path.endswith(".json"):
+        suffix = ".json"
+    else:
+        suffix = ".jsonl"  # Default to JSONL
+
+    # Extract a name from the URL for the temp file
+    url_name = Path(url_path).stem or "session"
+
+    temp_dir = Path(tempfile.gettempdir())
+    temp_file = temp_dir / f"claude-url-{url_name}{suffix}"
+    temp_file.write_text(response.text, encoding="utf-8")
+    return temp_file
+
+
 @cli.command("json")
-@click.argument("json_file", type=click.Path(exists=True))
+@click.argument("json_file", type=click.Path())
 @click.option(
     "-o",
     "--output",
@@ -1488,19 +1527,36 @@ def local_cmd(output, output_auto, repo, gist, include_json, open_browser, limit
     help="Open the generated index.html in your default browser (default if no -o specified).",
 )
 def json_cmd(json_file, output, output_auto, repo, gist, include_json, open_browser):
-    """Convert a Claude Code session JSON/JSONL file to HTML."""
+    """Convert a Claude Code session JSON/JSONL file or URL to HTML."""
+    # Handle URL input
+    if is_url(json_file):
+        click.echo(f"Fetching {json_file}...")
+        temp_file = fetch_url_to_tempfile(json_file)
+        json_file_path = temp_file
+        # Use URL path for naming
+        url_name = Path(json_file.split("?")[0]).stem or "session"
+    else:
+        # Validate that local file exists
+        json_file_path = Path(json_file)
+        if not json_file_path.exists():
+            raise click.ClickException(f"File not found: {json_file}")
+        url_name = None
+
     # Determine output directory and whether to open browser
     # If no -o specified, use temp dir and open browser by default
     auto_open = output is None and not gist and not output_auto
     if output_auto:
         # Use -o as parent dir (or current dir), with auto-named subdirectory
         parent_dir = Path(output) if output else Path(".")
-        output = parent_dir / Path(json_file).stem
+        output = parent_dir / (url_name or json_file_path.stem)
     elif output is None:
-        output = Path(tempfile.gettempdir()) / f"claude-session-{Path(json_file).stem}"
+        output = (
+            Path(tempfile.gettempdir())
+            / f"claude-session-{url_name or json_file_path.stem}"
+        )
 
     output = Path(output)
-    generate_html(json_file, output, github_repo=repo)
+    generate_html(json_file_path, output, github_repo=repo)
 
     # Show output directory
     click.echo(f"Output: {output.resolve()}")
@@ -1508,9 +1564,8 @@ def json_cmd(json_file, output, output_auto, repo, gist, include_json, open_brow
     # Copy JSON file to output directory if requested
     if include_json:
         output.mkdir(exist_ok=True)
-        json_source = Path(json_file)
-        json_dest = output / json_source.name
-        shutil.copy(json_file, json_dest)
+        json_dest = output / json_file_path.name
+        shutil.copy(json_file_path, json_dest)
         json_size_kb = json_dest.stat().st_size / 1024
         click.echo(f"JSON: {json_dest} ({json_size_kb:.1f} KB)")
 


### PR DESCRIPTION
> Make it so the `claude-code-transcripts json PATH` command can also accept a URL instead of a path, identified by it starting with http:// or https://

The json command now accepts URLs (http:// or https://) in addition to local file paths. When a URL is provided, the content is fetched and processed as a session file.

https://gistpreview.github.io/?bfcdd225a9a920c39e99ee225467f1cc/index.html