### PR TITLE
Update gist output domain to gisthost

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ claude-code-transcripts json session.json --gist
 This will output something like:
 ```
 Gist: https://gist.github.com/username/abc123def456
-Preview: https://gistpreview.github.io/?abc123def456/index.html
+Preview: https://gisthost.github.io/?abc123def456/index.html
 Files: /var/folders/.../session-id
 ```
 
-The preview URL uses [gistpreview.github.io](https://gistpreview.github.io/) to render your HTML gist. The tool automatically injects JavaScript to fix relative links when served through gistpreview.
+The preview URL uses [gisthost.github.io](https://gisthost.github.io/) to render your HTML gist. The tool automatically injects JavaScript to fix relative links when served through gisthost.
 
 Combine with `-o` to keep a local copy:
 

--- a/src/claude_code_transcripts/__init__.py
+++ b/src/claude_code_transcripts/__init__.py
@@ -1047,11 +1047,12 @@ document.querySelectorAll('.truncatable').forEach(function(wrapper) {
 });
 """
 
-# JavaScript to fix relative URLs when served via gistpreview.github.io
+# JavaScript to fix relative URLs when served via gisthost.github.io or gistpreview.github.io
 GIST_PREVIEW_JS = r"""
 (function() {
-    if (window.location.hostname !== 'gistpreview.github.io') return;
-    // URL format: https://gistpreview.github.io/?GIST_ID/filename.html
+    var hostname = window.location.hostname;
+    if (hostname !== 'gisthost.github.io' && hostname !== 'gistpreview.github.io') return;
+    // URL format: https://gisthost.github.io/?GIST_ID/filename.html
     var match = window.location.search.match(/^\?([^/]+)/);
     if (!match) return;
     var gistId = match[1];
@@ -1067,7 +1068,7 @@ GIST_PREVIEW_JS = r"""
     });
 
     // Handle fragment navigation after dynamic content loads
-    // gistpreview.github.io loads content dynamically, so the browser's
+    // gisthost.github.io/gistpreview.github.io loads content dynamically, so the browser's
     // native fragment navigation fails because the element doesn't exist yet
     function scrollToFragment() {
         var hash = window.location.hash;
@@ -1355,7 +1356,7 @@ def cli():
 @click.option(
     "--gist",
     is_flag=True,
-    help="Upload to GitHub Gist and output a gistpreview.github.io URL.",
+    help="Upload to GitHub Gist and output a gisthost.github.io URL.",
 )
 @click.option(
     "--json",
@@ -1443,7 +1444,7 @@ def local_cmd(output, output_auto, repo, gist, include_json, open_browser, limit
         inject_gist_preview_js(output)
         click.echo("Creating GitHub gist...")
         gist_id, gist_url = create_gist(output)
-        preview_url = f"https://gistpreview.github.io/?{gist_id}/index.html"
+        preview_url = f"https://gisthost.github.io/?{gist_id}/index.html"
         click.echo(f"Gist: {gist_url}")
         click.echo(f"Preview: {preview_url}")
 
@@ -1512,7 +1513,7 @@ def fetch_url_to_tempfile(url):
 @click.option(
     "--gist",
     is_flag=True,
-    help="Upload to GitHub Gist and output a gistpreview.github.io URL.",
+    help="Upload to GitHub Gist and output a gisthost.github.io URL.",
 )
 @click.option(
     "--json",
@@ -1574,7 +1575,7 @@ def json_cmd(json_file, output, output_auto, repo, gist, include_json, open_brow
         inject_gist_preview_js(output)
         click.echo("Creating GitHub gist...")
         gist_id, gist_url = create_gist(output)
-        preview_url = f"https://gistpreview.github.io/?{gist_id}/index.html"
+        preview_url = f"https://gisthost.github.io/?{gist_id}/index.html"
         click.echo(f"Gist: {gist_url}")
         click.echo(f"Preview: {preview_url}")
 
@@ -1823,7 +1824,7 @@ def generate_html_from_session_data(session_data, output_dir, github_repo=None):
 @click.option(
     "--gist",
     is_flag=True,
-    help="Upload to GitHub Gist and output a gistpreview.github.io URL.",
+    help="Upload to GitHub Gist and output a gisthost.github.io URL.",
 )
 @click.option(
     "--json",
@@ -1937,7 +1938,7 @@ def web_cmd(
         inject_gist_preview_js(output)
         click.echo("Creating GitHub gist...")
         gist_id, gist_url = create_gist(output)
-        preview_url = f"https://gistpreview.github.io/?{gist_id}/index.html"
+        preview_url = f"https://gisthost.github.io/?{gist_id}/index.html"
         click.echo(f"Gist: {gist_url}")
         click.echo(f"Preview: {preview_url}")
 

--- a/src/claude_code_transcripts/templates/search.js
+++ b/src/claude_code_transcripts/templates/search.js
@@ -18,8 +18,9 @@
     // Show search box (progressive enhancement)
     searchBox.style.display = 'flex';
 
-    // Gist preview support - detect if we're on gistpreview.github.io
-    var isGistPreview = window.location.hostname === 'gistpreview.github.io';
+    // Gist preview support - detect if we're on gisthost.github.io or gistpreview.github.io
+    var hostname = window.location.hostname;
+    var isGistPreview = hostname === 'gisthost.github.io' || hostname === 'gistpreview.github.io';
     var gistId = null;
     var gistOwner = null;
     var gistInfoLoaded = false;

--- a/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_index_html.html
+++ b/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_index_html.html
@@ -221,8 +221,9 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
     // Show search box (progressive enhancement)
     searchBox.style.display = 'flex';
 
-    // Gist preview support - detect if we're on gistpreview.github.io
-    var isGistPreview = window.location.hostname === 'gistpreview.github.io';
+    // Gist preview support - detect if we're on gisthost.github.io or gistpreview.github.io
+    var hostname = window.location.hostname;
+    var isGistPreview = hostname === 'gisthost.github.io' || hostname === 'gistpreview.github.io';
     var gistId = null;
     var gistOwner = null;
     var gistInfoLoaded = false;

--- a/tests/__snapshots__/test_generate_html/TestParseSessionFile.test_jsonl_generates_html.html
+++ b/tests/__snapshots__/test_generate_html/TestParseSessionFile.test_jsonl_generates_html.html
@@ -212,8 +212,9 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
     // Show search box (progressive enhancement)
     searchBox.style.display = 'flex';
 
-    // Gist preview support - detect if we're on gistpreview.github.io
-    var isGistPreview = window.location.hostname === 'gistpreview.github.io';
+    // Gist preview support - detect if we're on gisthost.github.io or gistpreview.github.io
+    var hostname = window.location.hostname;
+    var isGistPreview = hostname === 'gisthost.github.io' || hostname === 'gistpreview.github.io';
     var gistId = null;
     var gistOwner = null;
     var gistInfoLoaded = false;

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -596,7 +596,7 @@ class TestSessionGistOption:
         assert result.exit_code == 0
         assert "Creating GitHub gist" in result.output
         assert "gist.github.com" in result.output
-        assert "gistpreview.github.io" in result.output
+        assert "gisthost.github.io" in result.output
 
     def test_session_gist_with_output_dir(self, monkeypatch, output_dir):
         """Test that session --gist with -o uses specified directory."""
@@ -627,9 +627,9 @@ class TestSessionGistOption:
 
         assert result.exit_code == 0
         assert (output_dir / "index.html").exists()
-        # Verify JS was injected
+        # Verify JS was injected (checks for both domains for backwards compatibility)
         index_content = (output_dir / "index.html").read_text(encoding="utf-8")
-        assert "gistpreview.github.io" in index_content
+        assert "gisthost.github.io" in index_content
 
 
 class TestContinuationLongTexts:
@@ -874,7 +874,7 @@ class TestImportGistOption:
         assert result.exit_code == 0
         assert "Creating GitHub gist" in result.output
         assert "gist.github.com" in result.output
-        assert "gistpreview.github.io" in result.output
+        assert "gisthost.github.io" in result.output
 
 
 class TestVersionOption:


### PR DESCRIPTION
> The --gist option should output a link to gisthost.github.io rather than gistpreview.github.io
>
> The JavaScript logic injected into the pages should now work for both of those domains, so it should detect if the page is being served on gisthost.github.io OR gistpreview.github.io

- Update preview URLs to use gisthost.github.io instead of gistpreview.github.io
- Update JavaScript to detect both gisthost.github.io and gistpreview.github.io domains for backward compatibility with existing links
- Update help text and README to reference the new domain

https://gisthost.github.io/?e33364139d39625eda6fbbe8527f5902/index.html