### PR TITLE
Fix markdown list rendering without blank lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx",
     "jinja2",
     "markdown",
+    "mdx-breakless-lists",
     "questionary",
 ]
 

--- a/src/claude_code_transcripts/__init__.py
+++ b/src/claude_code_transcripts/__init__.py
@@ -632,7 +632,11 @@ def format_json(obj):
 def render_markdown_text(text):
     if not text:
         return ""
-    return markdown.markdown(text, extensions=["fenced_code", "tables"])
+    # Use mdx_breakless_lists extension to handle lists without blank lines
+    # This allows GitHub-flavored markdown style lists
+    return markdown.markdown(
+        text, extensions=["fenced_code", "tables", "mdx_breakless_lists"]
+    )
 
 
 def is_json_like(text):

--- a/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_001_html.html
+++ b/tests/__snapshots__/test_generate_html/TestGenerateHtml.test_generates_page_001_html.html
@@ -160,9 +160,11 @@ details.continuation[open] summary { border-radius: 12px 12px 0 0; margin-bottom
 <div class="message user" id="msg-2025-12-24T10-00-00-000Z"><div class="message-header"><span class="role-label">User</span><a href="#msg-2025-12-24T10-00-00-000Z" class="timestamp-link"><time datetime="2025-12-24T10:00:00.000Z" data-timestamp="2025-12-24T10:00:00.000Z">2025-12-24T10:00:00.000Z</time></a></div><div class="message-content">
 <div class="user-content"><p>Create a simple Python function to add two numbers</p></div></div></div>
 <div class="message assistant" id="msg-2025-12-24T10-00-05-000Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2025-12-24T10-00-05-000Z" class="timestamp-link"><time datetime="2025-12-24T10:00:05.000Z" data-timestamp="2025-12-24T10:00:05.000Z">2025-12-24T10:00:05.000Z</time></a></div><div class="message-content">
-<div class="thinking"><div class="thinking-label">Thinking</div><p>The user wants a simple addition function. I should:
-1. Create the function
-2. Add a basic test</p>
+<div class="thinking"><div class="thinking-label">Thinking</div><p>The user wants a simple addition function. I should:</p>
+<ol>
+<li>Create the function</li>
+<li>Add a basic test</li>
+</ol>
 <p>This is straightforward.</p></div>
 <div class="assistant-text"><p>I'll create a simple Python function for you. Let me write it now.</p></div><div class="file-tool write-tool" data-tool-id="toolu_write_001">
 <div class="file-tool-header write-header"><span class="file-tool-icon">📝</span> Write <span class="file-tool-path">math_utils.py</span></div>
@@ -252,10 +254,12 @@ def subtract(a: int, b: int) -&gt; int:
 test_subtract - AssertionError: expected 5 but got None</pre></div><button class="expand-btn">Show more</button></div></div></div></div>
 <div class="message assistant" id="msg-2025-12-24T10-02-15-000Z"><div class="message-header"><span class="role-label">Assistant</span><a href="#msg-2025-12-24T10-02-15-000Z" class="timestamp-link"><time datetime="2025-12-24T10:02:15.000Z" data-timestamp="2025-12-24T10:02:15.000Z">2025-12-24T10:02:15.000Z</time></a></div><div class="message-content">
 <div class="assistant-text"><p>There's a test failure. I need to check the test file and fix it.</p>
-<p>Here's some <strong>markdown</strong> content with:
-- A bullet list
-- <code>inline code</code>
-- A <a href="https://example.com">link</a></p>
+<p>Here's some <strong>markdown</strong> content with:</p>
+<ul>
+<li>A bullet list</li>
+<li><code>inline code</code></li>
+<li>A <a href="https://example.com">link</a></li>
+</ul>
 <pre><code class="language-python">def example():
     return 42
 </code></pre></div></div></div>

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -131,6 +131,22 @@ class TestRenderFunctions:
         assert render_markdown_text("") == ""
         assert render_markdown_text(None) == ""
 
+    def test_render_markdown_text_bullets_without_blank_line(self):
+        """Test that bullet points work even without a blank line before them.
+
+        This is a common pattern in Claude's responses where lists immediately
+        follow text without a blank line separator.
+        """
+        text = "Here's a list:\n- Item 1\n- Item 2\n- Item 3"
+        result = render_markdown_text(text)
+        # Should render as a proper list, not as plain text
+        assert "<ul>" in result
+        assert "<li>Item 1</li>" in result
+        assert "<li>Item 2</li>" in result
+        assert "<li>Item 3</li>" in result
+        # Should NOT render the dashes as literal text
+        assert "- Item 1" not in result
+
     def test_format_json(self, snapshot_html):
         """Test JSON formatting."""
         result = format_json({"key": "value", "number": 42, "nested": {"a": 1}})


### PR DESCRIPTION
Fixes bullet points and numbered lists that immediately follow text without a blank line separator.

## Changes
- Added `mdx-breakless-lists` dependency to handle GitHub-flavored markdown style lists
- Updated `render_markdown_text()` to use the `mdx_breakless_lists` extension
- Added test to verify lists render correctly without blank lines
- Updated snapshot for improved list formatting

## Background
The Python markdown library requires a blank line before lists by default. However, Claude's responses often include lists immediately after text without blank lines. The [`mdx-breakless-lists`](https://github.com/adamb70/mdx-breakless-lists) extension is the canonical solution for this, allowing GitHub-flavored markdown style lists.

## Testing
- All 112 tests pass
- New test verifies list rendering without blank lines
- Snapshot updated to reflect improved formatting