### PR TITLE
Skip multi-part usernames in project directory names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "black>=26.1.0",
     "pytest>=9.0.2",
     "pytest-httpx>=0.35.0",
     "syrupy>=5.0.0",


### PR DESCRIPTION
## Summary

Previously the
> # Skip the first part if it looks like a username (before common dirs)
resulted in local multi-part usernames like `my.name` become `my-name` and subsequently only `my` was removed by:
```
if i == 0 and not found_project:
    # Check if next parts contain common dirs
    remaining = [p.lower() for p in parts[i + 1 :]]
    if any(d in remaining for d in skip_dirs):
        continue
```
Which resulted in unsightly local paths like `name-github-some-project` which should really be `github-some-project`.

This PR:
- Strips the current user's username (with dots converted to dashes) as a prefix when generating display names (and output paths) for local project directories
- Handles multi-part usernames like `first.last` that get encoded as `first-last-` in the directory name
- Falls back to skipping the first part if a skip_dir exists later, when the username prefix doesn't match
- Preserves original behavior of skipping all skip_dirs (`projects`, `code`, `repos`, `src`, `dev`, `work`, `documents`)
- Added tests for multi-part username prefix stripping

🤖 Generated with [Claude Code](https://claude.ai/code)