### PR TITLE
Add PDF and DOCX export formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "questionary",
 ]
 
+[project.optional-dependencies]
+pdf = ["reportlab>=4.0"]
+docx = ["python-docx>=1.1"]
+export = ["reportlab>=4.0", "python-docx>=1.1"]
+
 [project.urls]
 Homepage = "https://github.com/simonw/claude-code-transcripts"
 Changelog = "https://github.com/simonw/claude-code-transcripts/releases"

--- a/src/claude_code_transcripts/__init__.py
+++ b/src/claude_code_transcripts/__init__.py
@@ -1286,6 +1286,60 @@ def create_gist(output_dir, public=False):
         )
 
 
+def _open_file(filepath):
+    """Open a file with the system's default application."""
+    filepath = Path(filepath)
+    if platform.system() == "Darwin":
+        subprocess.run(["open", str(filepath)])
+    elif platform.system() == "Windows":
+        os.startfile(str(filepath))
+    else:
+        subprocess.run(["xdg-open", str(filepath)])
+
+
+def _run_export(
+    source, output, output_auto, file_stem, output_format, repo, open_browser
+):
+    """Run PDF or DOCX export. Shared logic for local/json/web CLI commands.
+
+    Args:
+        source: Path to session file, or dict with 'loglines' key
+        output: User-provided output path (or None)
+        output_auto: Whether --output-auto was used
+        file_stem: Base name for auto-generated output file
+        output_format: "pdf" or "docx"
+        repo: GitHub repo string (or None)
+        open_browser: Whether --open was passed
+
+    Returns:
+        The resolved output Path.
+    """
+    ext = f".{output_format}"
+    auto_open = output is None
+    if output_auto:
+        parent_dir = Path(output) if output else Path(".")
+        output = parent_dir / f"{file_stem}{ext}"
+    elif output is None:
+        output = Path(tempfile.gettempdir()) / f"claude-session-{file_stem}{ext}"
+    output = Path(output)
+    if output.suffix != ext:
+        output = output.with_suffix(ext)
+
+    if output_format == "pdf":
+        from .pdf_export import generate_pdf as _generate_pdf
+
+        _generate_pdf(source, output, github_repo=repo)
+    else:
+        from .docx_export import generate_docx
+
+        generate_docx(source, output, github_repo=repo)
+
+    click.echo(f"Output: {output.resolve()}")
+    if open_browser or auto_open:
+        _open_file(output)
+    return output
+
+
 def generate_pagination_html(current_page, total_pages):
     return _macros.pagination(current_page, total_pages)
 
@@ -1293,6 +1347,15 @@ def generate_pagination_html(current_page, total_pages):
 def generate_index_pagination_html(total_pages):
     """Generate pagination for index page where Index is current (first page)."""
     return _macros.index_pagination(total_pages)
+
+
+from .export_helpers import (  # noqa: E402
+    extract_conversations,
+    load_conversations,
+    count_prompts_and_messages,
+    generate_single_page_html,
+    generate_pdf,
+)
 
 
 def generate_html(json_path, output_dir, github_repo=None):
@@ -1318,38 +1381,7 @@ def generate_html(json_path, output_dir, github_repo=None):
     global _github_repo
     _github_repo = github_repo
 
-    conversations = []
-    current_conv = None
-    for entry in loglines:
-        log_type = entry.get("type")
-        timestamp = entry.get("timestamp", "")
-        is_compact_summary = entry.get("isCompactSummary", False)
-        message_data = entry.get("message", {})
-        if not message_data:
-            continue
-        # Convert message dict to JSON string for compatibility with existing render functions
-        message_json = json.dumps(message_data)
-        is_user_prompt = False
-        user_text = None
-        if log_type == "user":
-            content = message_data.get("content", "")
-            text = extract_text_from_content(content)
-            if text:
-                is_user_prompt = True
-                user_text = text
-        if is_user_prompt:
-            if current_conv:
-                conversations.append(current_conv)
-            current_conv = {
-                "user_text": user_text,
-                "timestamp": timestamp,
-                "messages": [(log_type, message_json, timestamp)],
-                "is_continuation": bool(is_compact_summary),
-            }
-        elif current_conv:
-            current_conv["messages"].append((log_type, message_json, timestamp))
-    if current_conv:
-        conversations.append(current_conv)
+    conversations = extract_conversations(loglines)
 
     total_convs = len(conversations)
     total_pages = (total_convs + PROMPTS_PER_PAGE - 1) // PROMPTS_PER_PAGE
@@ -1516,8 +1548,21 @@ def cli():
     default=10,
     help="Maximum number of sessions to show (default: 10)",
 )
-def local_cmd(output, output_auto, repo, gist, include_json, open_browser, limit):
-    """Select and convert a local Claude Code session to HTML."""
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["html", "pdf", "docx"], case_sensitive=False),
+    default="html",
+    help="Output format (default: html).",
+)
+def local_cmd(
+    output, output_auto, repo, gist, include_json, open_browser, limit, output_format
+):
+    """Select and convert a local Claude Code session to HTML, PDF, or DOCX."""
+    if gist and output_format != "html":
+        raise click.ClickException("--gist is only supported with HTML format.")
+
     projects_folder = Path.home() / ".claude" / "projects"
 
     if not projects_folder.exists():
@@ -1556,11 +1601,21 @@ def local_cmd(output, output_auto, repo, gist, include_json, open_browser, limit
 
     session_file = selected
 
-    # Determine output directory and whether to open browser
-    # If no -o specified, use temp dir and open browser by default
+    if output_format in ("pdf", "docx"):
+        _run_export(
+            session_file,
+            output,
+            output_auto,
+            session_file.stem,
+            output_format,
+            repo,
+            open_browser,
+        )
+        return
+
+    # HTML format (original behavior)
     auto_open = output is None and not gist and not output_auto
     if output_auto:
-        # Use -o as parent dir (or current dir), with auto-named subdirectory
         parent_dir = Path(output) if output else Path(".")
         output = parent_dir / session_file.stem
     elif output is None:
@@ -1639,7 +1694,7 @@ def fetch_url_to_tempfile(url):
     "-o",
     "--output",
     type=click.Path(),
-    help="Output directory. If not specified, writes to temp dir and opens in browser.",
+    help="Output directory (or file for pdf/docx). If not specified, writes to temp dir and opens.",
 )
 @click.option(
     "-a",
@@ -1666,10 +1721,30 @@ def fetch_url_to_tempfile(url):
     "--open",
     "open_browser",
     is_flag=True,
-    help="Open the generated index.html in your default browser (default if no -o specified).",
+    help="Open the generated output in your default application (default if no -o specified).",
 )
-def json_cmd(json_file, output, output_auto, repo, gist, include_json, open_browser):
-    """Convert a Claude Code session JSON/JSONL file or URL to HTML."""
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["html", "pdf", "docx"], case_sensitive=False),
+    default="html",
+    help="Output format (default: html).",
+)
+def json_cmd(
+    json_file,
+    output,
+    output_auto,
+    repo,
+    gist,
+    include_json,
+    open_browser,
+    output_format,
+):
+    """Convert a Claude Code session JSON/JSONL file or URL to HTML, PDF, or DOCX."""
+    if gist and output_format != "html":
+        raise click.ClickException("--gist is only supported with HTML format.")
+
     # Handle URL input
     if is_url(json_file):
         click.echo(f"Fetching {json_file}...")
@@ -1684,18 +1759,27 @@ def json_cmd(json_file, output, output_auto, repo, gist, include_json, open_brow
             raise click.ClickException(f"File not found: {json_file}")
         url_name = None
 
-    # Determine output directory and whether to open browser
-    # If no -o specified, use temp dir and open browser by default
+    file_stem = url_name or json_file_path.stem
+
+    if output_format in ("pdf", "docx"):
+        _run_export(
+            json_file_path,
+            output,
+            output_auto,
+            file_stem,
+            output_format,
+            repo,
+            open_browser,
+        )
+        return
+
+    # HTML format (original behavior)
     auto_open = output is None and not gist and not output_auto
     if output_auto:
-        # Use -o as parent dir (or current dir), with auto-named subdirectory
         parent_dir = Path(output) if output else Path(".")
-        output = parent_dir / (url_name or json_file_path.stem)
+        output = parent_dir / file_stem
     elif output is None:
-        output = (
-            Path(tempfile.gettempdir())
-            / f"claude-session-{url_name or json_file_path.stem}"
-        )
+        output = Path(tempfile.gettempdir()) / f"claude-session-{file_stem}"
 
     output = Path(output)
     generate_html(json_file_path, output, github_repo=repo)
@@ -1792,38 +1876,7 @@ def generate_html_from_session_data(session_data, output_dir, github_repo=None):
     global _github_repo
     _github_repo = github_repo
 
-    conversations = []
-    current_conv = None
-    for entry in loglines:
-        log_type = entry.get("type")
-        timestamp = entry.get("timestamp", "")
-        is_compact_summary = entry.get("isCompactSummary", False)
-        message_data = entry.get("message", {})
-        if not message_data:
-            continue
-        # Convert message dict to JSON string for compatibility with existing render functions
-        message_json = json.dumps(message_data)
-        is_user_prompt = False
-        user_text = None
-        if log_type == "user":
-            content = message_data.get("content", "")
-            text = extract_text_from_content(content)
-            if text:
-                is_user_prompt = True
-                user_text = text
-        if is_user_prompt:
-            if current_conv:
-                conversations.append(current_conv)
-            current_conv = {
-                "user_text": user_text,
-                "timestamp": timestamp,
-                "messages": [(log_type, message_json, timestamp)],
-                "is_continuation": bool(is_compact_summary),
-            }
-        elif current_conv:
-            current_conv["messages"].append((log_type, message_json, timestamp))
-    if current_conv:
-        conversations.append(current_conv)
+    conversations = extract_conversations(loglines)
 
     total_convs = len(conversations)
     total_pages = (total_convs + PROMPTS_PER_PAGE - 1) // PROMPTS_PER_PAGE
@@ -1981,7 +2034,15 @@ def generate_html_from_session_data(session_data, output_dir, github_repo=None):
     "--open",
     "open_browser",
     is_flag=True,
-    help="Open the generated index.html in your default browser (default if no -o specified).",
+    help="Open the generated output in your default application (default if no -o specified).",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["html", "pdf", "docx"], case_sensitive=False),
+    default="html",
+    help="Output format (default: html).",
 )
 def web_cmd(
     session_id,
@@ -1993,8 +2054,9 @@ def web_cmd(
     gist,
     include_json,
     open_browser,
+    output_format,
 ):
-    """Select and convert a web session from the Claude API to HTML.
+    """Select and convert a web session from the Claude API to HTML, PDF, or DOCX.
 
     If SESSION_ID is not provided, displays an interactive picker to select a session.
     """
@@ -2056,11 +2118,24 @@ def web_cmd(
     except httpx.RequestError as e:
         raise click.ClickException(f"Network error: {e}")
 
-    # Determine output directory and whether to open browser
-    # If no -o specified, use temp dir and open browser by default
+    if gist and output_format != "html":
+        raise click.ClickException("--gist is only supported with HTML format.")
+
+    if output_format in ("pdf", "docx"):
+        _run_export(
+            session_data,
+            output,
+            output_auto,
+            session_id,
+            output_format,
+            repo,
+            open_browser,
+        )
+        return
+
+    # HTML format (original behavior)
     auto_open = output is None and not gist and not output_auto
     if output_auto:
-        # Use -o as parent dir (or current dir), with auto-named subdirectory
         parent_dir = Path(output) if output else Path(".")
         output = parent_dir / session_id
     elif output is None:

--- a/src/claude_code_transcripts/docx_export.py
+++ b/src/claude_code_transcripts/docx_export.py
@@ -1,0 +1,573 @@
+"""DOCX export for Claude Code transcripts."""
+
+import json
+import re
+
+import click
+
+from . import COMMIT_PATTERN
+
+
+def _add_hyperlink(
+    paragraph, text, url, font_name=None, font_size=None, color_rgb=None
+):
+    """Add a clickable hyperlink run to a paragraph.
+
+    python-docx doesn't have built-in hyperlink support, so we build the XML directly.
+    """
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+
+    part = paragraph.part
+    r_id = part.relate_to(
+        url,
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+        is_external=True,
+    )
+
+    hyperlink = OxmlElement("w:hyperlink")
+    hyperlink.set(qn("r:id"), r_id)
+
+    new_run = OxmlElement("w:r")
+    rPr = OxmlElement("w:rPr")
+
+    u = OxmlElement("w:u")
+    u.set(qn("w:val"), "single")
+    rPr.append(u)
+
+    c = OxmlElement("w:color")
+    if color_rgb:
+        c.set(qn("w:val"), f"{color_rgb[0]:02X}{color_rgb[1]:02X}{color_rgb[2]:02X}")
+    else:
+        c.set(qn("w:val"), "0563C1")
+    rPr.append(c)
+
+    if font_name:
+        rFonts = OxmlElement("w:rFonts")
+        rFonts.set(qn("w:ascii"), font_name)
+        rFonts.set(qn("w:hAnsi"), font_name)
+        rPr.append(rFonts)
+
+    if font_size:
+        sz = OxmlElement("w:sz")
+        sz.set(qn("w:val"), str(font_size * 2))  # half-points
+        rPr.append(sz)
+
+    new_run.append(rPr)
+
+    t = OxmlElement("w:t")
+    t.text = text
+    new_run.append(t)
+
+    hyperlink.append(new_run)
+    paragraph._p.append(hyperlink)
+
+
+def _set_paragraph_shading(paragraph, hex_color):
+    """Set background color on a paragraph via XML."""
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+
+    pPr = paragraph._p.get_or_add_pPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), hex_color)
+    pPr.append(shd)
+
+
+def _set_paragraph_border(paragraph, color, side="left", size=12):
+    """Set a single border on a paragraph via XML."""
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+
+    pPr = paragraph._p.get_or_add_pPr()
+    pBdr = pPr.find(qn("w:pBdr"))
+    if pBdr is None:
+        pBdr = OxmlElement("w:pBdr")
+        pPr.append(pBdr)
+    border = OxmlElement(f"w:{side}")
+    border.set(qn("w:val"), "single")
+    border.set(qn("w:sz"), str(size))
+    border.set(qn("w:space"), "4")
+    border.set(qn("w:color"), color)
+    pBdr.append(border)
+
+
+def _add_markdown_runs(paragraph, text, Pt, RGBColor, base_size=10):
+    """Parse markdown inline formatting and add styled runs to a paragraph.
+
+    Handles: **bold**, *italic*, `code`, [text](url).
+    """
+    # Tokenize the text into segments with formatting
+    # Pattern matches: **bold**, *italic*, `code`, [text](url)
+    pattern = re.compile(
+        r"(\*\*(.+?)\*\*)"  # bold
+        r"|(\*(.+?)\*)"  # italic
+        r"|(`([^`]+)`)"  # inline code
+        r"|(\[([^\]]+)\]\(([^)]+)\))"  # links
+    )
+
+    pos = 0
+    for m in pattern.finditer(text):
+        # Add text before this match
+        if m.start() > pos:
+            run = paragraph.add_run(text[pos : m.start()])
+            run.font.size = Pt(base_size)
+
+        if m.group(2):  # bold
+            run = paragraph.add_run(m.group(2))
+            run.bold = True
+            run.font.size = Pt(base_size)
+        elif m.group(4):  # italic
+            run = paragraph.add_run(m.group(4))
+            run.italic = True
+            run.font.size = Pt(base_size)
+        elif m.group(6):  # code
+            run = paragraph.add_run(m.group(6))
+            run.font.name = "Courier New"
+            run.font.size = Pt(base_size - 1)
+            run.font.color.rgb = RGBColor(0xC6, 0x28, 0x28)
+        elif m.group(8):  # link
+            _add_hyperlink(paragraph, m.group(8), m.group(9))
+
+        pos = m.end()
+
+    # Add remaining text
+    if pos < len(text):
+        run = paragraph.add_run(text[pos:])
+        run.font.size = Pt(base_size)
+
+
+def generate_docx(source, output_path, github_repo=None):
+    """Generate a DOCX from a session file or session data dict.
+
+    Args:
+        source: Path to session file, or dict with 'loglines' key
+        output_path: Path for the output DOCX file
+        github_repo: Optional GitHub repo for commit links
+    """
+    try:
+        from docx import Document
+        from docx.shared import Pt, RGBColor
+    except ImportError:
+        raise click.ClickException(
+            "python-docx is required for DOCX export. "
+            "Install with: uv pip install 'claude-code-transcripts[docx]'"
+        )
+
+    from .export_helpers import load_conversations, count_prompts_and_messages
+    from . import extract_text_from_content, is_tool_result_message
+
+    conversations, github_repo = load_conversations(source, github_repo)
+
+    doc = Document()
+
+    # Set default font
+    style = doc.styles["Normal"]
+    font = style.font
+    font.name = "Calibri"
+    font.size = Pt(10)
+
+    # Title
+    doc.add_heading("Claude Code Transcript", level=1)
+
+    # Stats
+    prompt_count, message_count = count_prompts_and_messages(conversations)
+    stats_para = doc.add_paragraph()
+    stats_run = stats_para.add_run(
+        f"{prompt_count} prompts \u00b7 {message_count} messages"
+    )
+    stats_run.font.color.rgb = RGBColor(0x75, 0x75, 0x75)
+    stats_run.font.size = Pt(9)
+
+    doc.add_paragraph()  # spacer
+
+    for conv in conversations:
+        for log_type, message_json, timestamp in conv["messages"]:
+            if not message_json:
+                continue
+            try:
+                message_data = json.loads(message_json)
+            except json.JSONDecodeError:
+                continue
+
+            content = message_data.get("content", "")
+
+            if log_type == "user":
+                if is_tool_result_message(message_data):
+                    _render_tool_results_docx(
+                        doc, content, timestamp, github_repo, Pt, RGBColor
+                    )
+                else:
+                    # User message
+                    header = _add_role_header(
+                        doc, "USER", timestamp, RGBColor(0x19, 0x76, 0xD2), Pt, RGBColor
+                    )
+                    _set_paragraph_shading(header, "E3F2FD")
+                    _set_paragraph_border(header, "1976D2", "left", 12)
+                    text = extract_text_from_content(content)
+                    if text:
+                        para = doc.add_paragraph(text)
+                        _set_paragraph_shading(para, "E3F2FD")
+                        _set_paragraph_border(para, "1976D2", "left", 12)
+
+            elif log_type == "assistant":
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        block_type = block.get("type", "")
+
+                        if block_type == "text":
+                            text = block.get("text", "")
+                            if text:
+                                _add_role_header(
+                                    doc,
+                                    "ASSISTANT",
+                                    timestamp,
+                                    RGBColor(0x9E, 0x9E, 0x9E),
+                                    Pt,
+                                    RGBColor,
+                                )
+                                _add_markdown_text(doc, text, Pt, RGBColor)
+
+                        elif block_type == "thinking":
+                            text = block.get("thinking", "")
+                            if text:
+                                para = doc.add_paragraph()
+                                run = para.add_run("Thinking: ")
+                                run.font.color.rgb = RGBColor(0xF5, 0x7C, 0x00)
+                                run.font.size = Pt(8)
+                                run.bold = True
+                                run = para.add_run(text[:500])
+                                run.font.color.rgb = RGBColor(0x66, 0x66, 0x66)
+                                run.font.size = Pt(8)
+                                run.italic = True
+                                if len(text) > 500:
+                                    run = para.add_run("...")
+                                    run.font.color.rgb = RGBColor(0x66, 0x66, 0x66)
+                                    run.font.size = Pt(8)
+                                _set_paragraph_shading(para, "FFF8E1")
+                                _set_paragraph_border(para, "FFC107", "left", 12)
+
+                        elif block_type == "image":
+                            _add_image_block_docx(doc, block)
+
+                        elif block_type == "tool_use":
+                            tool_name = block.get("name", "Unknown")
+                            tool_input = block.get("input", {})
+                            _render_tool_use_docx(
+                                doc, tool_name, tool_input, Pt, RGBColor
+                            )
+
+                        elif block_type == "tool_result":
+                            result_content = block.get("content", "")
+                            is_error = block.get("is_error", False)
+                            _render_single_tool_result_docx(
+                                doc,
+                                result_content,
+                                is_error,
+                                github_repo,
+                                Pt,
+                                RGBColor,
+                            )
+
+    from pathlib import Path
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(output_path))
+
+
+def _add_role_header(doc, role, timestamp, color, Pt, RGBColor):
+    """Add a role header paragraph (USER, ASSISTANT, etc.). Returns the paragraph."""
+    para = doc.add_paragraph()
+    run = para.add_run(role)
+    run.bold = True
+    run.font.color.rgb = color
+    run.font.size = Pt(8)
+    if timestamp:
+        run = para.add_run(f"  {timestamp}")
+        run.font.color.rgb = RGBColor(0x75, 0x75, 0x75)
+        run.font.size = Pt(7)
+    return para
+
+
+def _add_markdown_text(doc, text, Pt, RGBColor):
+    """Add text with basic markdown formatting to the document."""
+    lines = text.split("\n")
+    current_block = []
+
+    def flush_block():
+        if current_block:
+            joined = "\n".join(current_block)
+            if joined.strip():
+                para = doc.add_paragraph()
+                _add_markdown_runs(para, joined, Pt, RGBColor)
+            current_block.clear()
+
+    in_code_block = False
+    code_lines = []
+
+    for line in lines:
+        if line.startswith("```"):
+            if in_code_block:
+                # End code block
+                in_code_block = False
+                flush_block()
+                para = doc.add_paragraph()
+                code_text = "\n".join(code_lines)
+                run = para.add_run(code_text)
+                run.font.name = "Courier New"
+                run.font.size = Pt(8)
+                run.font.color.rgb = RGBColor(0xAE, 0xD5, 0x81)
+                _set_paragraph_shading(para, "263238")
+                code_lines.clear()
+            else:
+                # Start code block
+                in_code_block = True
+                flush_block()
+        elif in_code_block:
+            code_lines.append(line)
+        elif line.startswith("# "):
+            flush_block()
+            doc.add_heading(line[2:], level=2)
+        elif line.startswith("## "):
+            flush_block()
+            doc.add_heading(line[3:], level=3)
+        elif line.startswith("### "):
+            flush_block()
+            doc.add_heading(line[4:], level=4)
+        elif line.startswith("- ") or line.startswith("* "):
+            flush_block()
+            para = doc.add_paragraph(style="List Bullet")
+            _add_markdown_runs(para, line[2:], Pt, RGBColor)
+        else:
+            current_block.append(line)
+
+    # Flush any remaining code block
+    if in_code_block and code_lines:
+        para = doc.add_paragraph()
+        code_text = "\n".join(code_lines)
+        run = para.add_run(code_text)
+        run.font.name = "Courier New"
+        run.font.size = Pt(8)
+        _set_paragraph_shading(para, "263238")
+
+    flush_block()
+
+
+def _render_tool_use_docx(doc, tool_name, tool_input, Pt, RGBColor):
+    """Render a tool use block."""
+    para = doc.add_paragraph()
+    run = para.add_run(f"\u2699 {tool_name}")
+    run.bold = True
+    run.font.color.rgb = RGBColor(0x9C, 0x27, 0xB0)
+    run.font.size = Pt(9)
+    _set_paragraph_shading(para, "F3E5F5")
+    _set_paragraph_border(para, "9C27B0", "left", 12)
+
+    if tool_name == "Write":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            para = doc.add_paragraph()
+            run = para.add_run(f"  \u2192 {file_path}")
+            run.font.name = "Courier New"
+            run.font.size = Pt(8)
+        content = tool_input.get("content", "")
+        if content:
+            para = doc.add_paragraph()
+            run = para.add_run(content[:1000])
+            run.font.name = "Courier New"
+            run.font.size = Pt(7)
+            run.font.color.rgb = RGBColor(0xAE, 0xD5, 0x81)
+            _set_paragraph_shading(para, "263238")
+            if len(content) > 1000:
+                run = para.add_run(f"\n... ({len(content)} chars total)")
+                run.font.size = Pt(7)
+                run.font.color.rgb = RGBColor(0x75, 0x75, 0x75)
+
+    elif tool_name == "Edit":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            para = doc.add_paragraph()
+            run = para.add_run(f"  \u2192 {file_path}")
+            run.font.name = "Courier New"
+            run.font.size = Pt(8)
+        old_str = tool_input.get("old_string", "")
+        new_str = tool_input.get("new_string", "")
+        if old_str:
+            para = doc.add_paragraph()
+            run = para.add_run(f"- {old_str[:500]}")
+            run.font.name = "Courier New"
+            run.font.size = Pt(7)
+            run.font.color.rgb = RGBColor(0xB7, 0x1C, 0x1C)
+        if new_str:
+            para = doc.add_paragraph()
+            run = para.add_run(f"+ {new_str[:500]}")
+            run.font.name = "Courier New"
+            run.font.size = Pt(7)
+            run.font.color.rgb = RGBColor(0x1B, 0x5E, 0x20)
+
+    elif tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if command:
+            para = doc.add_paragraph()
+            run = para.add_run(f"$ {command}")
+            run.font.name = "Courier New"
+            run.font.size = Pt(8)
+            run.font.color.rgb = RGBColor(0xAE, 0xD5, 0x81)
+            _set_paragraph_shading(para, "263238")
+
+    else:
+        # Generic tool - show input as JSON
+        description = tool_input.get("description", "")
+        if description:
+            para = doc.add_paragraph()
+            run = para.add_run(description)
+            run.italic = True
+            run.font.size = Pt(8)
+            run.font.color.rgb = RGBColor(0x75, 0x75, 0x75)
+        display_input = {k: v for k, v in tool_input.items() if k != "description"}
+        if display_input:
+            input_text = json.dumps(display_input, indent=2, ensure_ascii=False)
+            if len(input_text) > 500:
+                input_text = input_text[:500] + "..."
+            para = doc.add_paragraph()
+            run = para.add_run(input_text)
+            run.font.name = "Courier New"
+            run.font.size = Pt(7)
+            run.font.color.rgb = RGBColor(0xAE, 0xD5, 0x81)
+            _set_paragraph_shading(para, "263238")
+
+
+def _render_tool_results_docx(
+    doc, content_blocks, timestamp, github_repo, Pt, RGBColor
+):
+    """Render tool result blocks from a user message."""
+    header = _add_role_header(
+        doc, "TOOL REPLY", timestamp, RGBColor(0xE6, 0x51, 0x00), Pt, RGBColor
+    )
+    _set_paragraph_shading(header, "E8F5E9")
+    _set_paragraph_border(header, "4CAF50", "left", 12)
+    for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
+        _render_single_tool_result_docx(
+            doc,
+            block.get("content", ""),
+            block.get("is_error", False),
+            github_repo,
+            Pt,
+            RGBColor,
+        )
+
+
+def _render_single_tool_result_docx(
+    doc, result_content, is_error, github_repo, Pt, RGBColor
+):
+    """Render a single tool result."""
+    bg_color = "FFEBEE" if is_error else "E8F5E9"
+    border_color = "B71C1C" if is_error else "4CAF50"
+
+    if isinstance(result_content, str):
+        # Check for commits
+        commits = list(COMMIT_PATTERN.finditer(result_content))
+        if commits:
+            # Render text between/around commits
+            last_end = 0
+            for match in commits:
+                before = result_content[last_end : match.start()].strip()
+                if before:
+                    para = doc.add_paragraph()
+                    run = para.add_run(before[:2000])
+                    run.font.name = "Courier New"
+                    run.font.size = Pt(7)
+                    _set_paragraph_shading(para, bg_color)
+                    _set_paragraph_border(para, border_color, "left", 12)
+                commit_hash = match.group(1)
+                commit_msg = match.group(2)
+                para = doc.add_paragraph()
+                if github_repo:
+                    link = f"https://github.com/{github_repo}/commit/{commit_hash}"
+                    _add_hyperlink(
+                        para,
+                        f"\U0001f4e6 {commit_hash[:7]}",
+                        link,
+                        font_name="Courier New",
+                        font_size=9,
+                        color_rgb=(0xE6, 0x51, 0x00),
+                    )
+                else:
+                    run = para.add_run(f"\U0001f4e6 {commit_hash[:7]}")
+                    run.font.name = "Courier New"
+                    run.font.color.rgb = RGBColor(0xE6, 0x51, 0x00)
+                    run.font.size = Pt(9)
+                run = para.add_run(f" {commit_msg}")
+                run.font.size = Pt(9)
+                _set_paragraph_shading(para, bg_color)
+                _set_paragraph_border(para, border_color, "left", 12)
+                last_end = match.end()
+            after = result_content[last_end:].strip()
+            if after:
+                para = doc.add_paragraph()
+                run = para.add_run(after[:2000])
+                run.font.name = "Courier New"
+                run.font.size = Pt(7)
+                _set_paragraph_shading(para, bg_color)
+                _set_paragraph_border(para, border_color, "left", 12)
+        else:
+            text = result_content[:2000]
+            if text.strip():
+                para = doc.add_paragraph()
+                run = para.add_run(text)
+                run.font.name = "Courier New"
+                run.font.size = Pt(7)
+                if is_error:
+                    run.font.color.rgb = RGBColor(0xB7, 0x1C, 0x1C)
+                if len(result_content) > 2000:
+                    run = para.add_run(f"\n... ({len(result_content)} chars total)")
+                    run.font.size = Pt(7)
+                    run.font.color.rgb = RGBColor(0x75, 0x75, 0x75)
+                _set_paragraph_shading(para, bg_color)
+                _set_paragraph_border(para, border_color, "left", 12)
+    elif isinstance(result_content, list):
+        for item in result_content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type", "")
+            if item_type == "text":
+                text = item.get("text", "")
+                if text.strip():
+                    para = doc.add_paragraph()
+                    run = para.add_run(text[:2000])
+                    run.font.name = "Courier New"
+                    run.font.size = Pt(7)
+                    _set_paragraph_shading(para, bg_color)
+                    _set_paragraph_border(para, border_color, "left", 12)
+            elif item_type == "image":
+                _add_image_block_docx(doc, item)
+
+
+def _add_image_block_docx(doc, block):
+    """Add an inline base64 image to the DOCX."""
+    import base64
+    import io
+
+    from docx.shared import Inches
+
+    source = block.get("source", {})
+    data = source.get("data", "")
+    if not data:
+        return
+
+    try:
+        image_bytes = base64.b64decode(data)
+        image_stream = io.BytesIO(image_bytes)
+        # Max width ~6.5 inches (letter page with 1" margins)
+        doc.add_picture(image_stream, width=Inches(6.5))
+    except Exception:
+        para = doc.add_paragraph()
+        run = para.add_run("[Image could not be rendered]")
+        run.italic = True

--- a/src/claude_code_transcripts/export_helpers.py
+++ b/src/claude_code_transcripts/export_helpers.py
@@ -1,0 +1,141 @@
+"""Shared helpers for PDF, DOCX, and single-page HTML export.
+
+All imports from the parent package are done inside function bodies
+to avoid circular imports.
+"""
+
+import json
+
+
+def extract_conversations(loglines):
+    """Extract conversations from loglines.
+
+    Groups loglines into conversations, where each conversation starts with
+    a user prompt and includes all subsequent messages until the next user prompt.
+
+    Returns a list of conversation dicts, each with keys:
+    - user_text: str
+    - timestamp: str
+    - messages: list of (log_type, message_json, timestamp) tuples
+    - is_continuation: bool
+    """
+    from . import extract_text_from_content
+
+    conversations = []
+    current_conv = None
+    for entry in loglines:
+        log_type = entry.get("type")
+        timestamp = entry.get("timestamp", "")
+        is_compact_summary = entry.get("isCompactSummary", False)
+        message_data = entry.get("message", {})
+        if not message_data:
+            continue
+        # Convert message dict to JSON string for compatibility with existing render functions
+        message_json = json.dumps(message_data)
+        is_user_prompt = False
+        user_text = None
+        if log_type == "user":
+            content = message_data.get("content", "")
+            text = extract_text_from_content(content)
+            if text:
+                is_user_prompt = True
+                user_text = text
+        if is_user_prompt:
+            if current_conv:
+                conversations.append(current_conv)
+            current_conv = {
+                "user_text": user_text,
+                "timestamp": timestamp,
+                "messages": [(log_type, message_json, timestamp)],
+                "is_continuation": bool(is_compact_summary),
+            }
+        elif current_conv:
+            current_conv["messages"].append((log_type, message_json, timestamp))
+    if current_conv:
+        conversations.append(current_conv)
+    return conversations
+
+
+def load_conversations(source, github_repo=None):
+    """Load and parse conversations from a session file or session data dict.
+
+    Args:
+        source: Path to session file, or dict with 'loglines' key
+        github_repo: Optional GitHub repo for commit links. If None, auto-detected.
+
+    Returns:
+        (conversations, github_repo) tuple
+    """
+    from . import parse_session_file, detect_github_repo
+
+    if isinstance(source, dict):
+        loglines = source.get("loglines", [])
+    else:
+        data = parse_session_file(source)
+        loglines = data.get("loglines", [])
+
+    if github_repo is None:
+        github_repo = detect_github_repo(loglines)
+
+    conversations = extract_conversations(loglines)
+    return conversations, github_repo
+
+
+def count_prompts_and_messages(conversations):
+    """Count prompts and messages across conversations.
+
+    Returns:
+        (prompt_count, message_count) tuple
+    """
+    prompt_count = sum(
+        1
+        for conv in conversations
+        if not conv.get("is_continuation")
+        and not conv["user_text"].startswith("Stop hook feedback:")
+    )
+    message_count = sum(len(conv["messages"]) for conv in conversations)
+    return prompt_count, message_count
+
+
+def generate_single_page_html(conversations):
+    """Render all conversations into a single HTML string suitable for PDF.
+
+    Returns a complete HTML document string with all content expanded
+    and no JavaScript or pagination.
+    """
+    from . import render_message, get_template, CSS
+
+    messages_html_parts = []
+    for conv in conversations:
+        is_first = True
+        for log_type, message_json, timestamp in conv["messages"]:
+            msg_html = render_message(log_type, message_json, timestamp)
+            if msg_html:
+                # For single-page, show continuation summaries expanded (no <details>)
+                if is_first and conv.get("is_continuation"):
+                    msg_html = f'<div class="continuation-expanded">{msg_html}</div>'
+                messages_html_parts.append(msg_html)
+            is_first = False
+
+    prompt_count, message_count = count_prompts_and_messages(conversations)
+
+    template = get_template("single_page.html")
+    return template.render(
+        css=CSS,
+        prompt_count=prompt_count,
+        message_count=message_count,
+        messages_html="".join(messages_html_parts),
+    )
+
+
+def generate_pdf(source, output_path, github_repo=None):
+    """Generate a PDF from a session file or session data dict.
+
+    Args:
+        source: Path to session file, or dict with 'loglines' key
+        output_path: Path for the output PDF file
+        github_repo: Optional GitHub repo for commit links
+    """
+    from .pdf_export import generate_pdf as _generate_pdf
+
+    _generate_pdf(source, output_path, github_repo=github_repo)

--- a/src/claude_code_transcripts/pdf_export.py
+++ b/src/claude_code_transcripts/pdf_export.py
@@ -1,0 +1,665 @@
+"""PDF export for Claude Code transcripts."""
+
+import json
+import re
+
+import click
+
+# A4=595pt - 2*54pt margins = 487pt; box padding 10+8+3pt border ≈ 466pt
+# Courier 8pt ≈ 4.8pt/char → ~97 chars; use 95 for safety
+_MAX_LINE_WIDTH = 95
+
+
+def _wrap_long_lines(text):
+    """Wrap long lines so Preformatted text stays within the page."""
+    import textwrap
+
+    out = []
+    for line in text.split("\n"):
+        if len(line) > _MAX_LINE_WIDTH:
+            out.extend(
+                textwrap.wrap(
+                    line,
+                    _MAX_LINE_WIDTH,
+                    break_long_words=True,
+                    break_on_hyphens=False,
+                )
+            )
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def generate_pdf(source, output_path, github_repo=None):
+    """Generate a styled PDF from a Claude Code session.
+
+    Args:
+        source: Path to session file, or dict with 'loglines' key
+        output_path: Path for the output PDF file
+        github_repo: Optional GitHub repo string for commit links
+    """
+    try:
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.styles import ParagraphStyle
+        from reportlab.lib.colors import HexColor
+        from reportlab.lib.units import inch
+        from reportlab.platypus import (
+            SimpleDocTemplate,
+            Paragraph,
+            Spacer,
+        )
+    except ImportError:
+        raise click.ClickException(
+            "PDF export requires reportlab. "
+            "Install with: uv pip install 'claude-code-transcripts[pdf]'"
+        )
+
+    from .export_helpers import load_conversations, count_prompts_and_messages
+    from . import extract_text_from_content, is_tool_result_message, COMMIT_PATTERN
+
+    conversations, github_repo = load_conversations(source, github_repo)
+
+    from pathlib import Path
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    doc = SimpleDocTemplate(
+        str(output_path),
+        pagesize=A4,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+        topMargin=0.75 * inch,
+        bottomMargin=0.75 * inch,
+    )
+
+    # --- Styles ---
+
+    def _escape(text):
+        """Escape text for reportlab Paragraph XML."""
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    MAX_LINES = 55  # ~672pt frame / ~10pt per line, with padding margin
+
+    def _truncate(text, max_len=3000):
+        if len(text) > max_len:
+            text = text[:max_len] + f"\n... ({len(text)} chars total)"
+        text = _wrap_long_lines(text)
+        lines = text.split("\n")
+        if len(lines) > MAX_LINES:
+            text = "\n".join(lines[:MAX_LINES]) + f"\n... ({len(lines)} lines total)"
+        return text
+
+    # Role header styles (allocated once, reused across messages)
+    style_user_role = ParagraphStyle(
+        "UserRole",
+        fontName="Helvetica-Bold",
+        fontSize=9,
+        textColor=HexColor("#E65100"),
+        spaceBefore=12,
+        spaceAfter=2,
+    )
+    style_user_text = ParagraphStyle(
+        "UserText",
+        fontName="Helvetica",
+        fontSize=10,
+        leading=14,
+        textColor=HexColor("#333333"),
+        backColor=HexColor("#FFF3E0"),
+        borderPadding=8,
+        spaceBefore=2,
+        spaceAfter=4,
+    )
+    style_assistant_role = ParagraphStyle(
+        "AssistantRole",
+        fontName="Helvetica",
+        fontSize=9,
+        textColor=HexColor("#666666"),
+        spaceBefore=6,
+        spaceAfter=2,
+    )
+    style_assistant_text = ParagraphStyle(
+        "AssistantText",
+        fontName="Helvetica",
+        fontSize=10,
+        leading=14,
+        textColor=HexColor("#333333"),
+        spaceBefore=2,
+        spaceAfter=4,
+        leftIndent=10,
+    )
+    style_thinking = ParagraphStyle(
+        "Thinking",
+        fontName="Helvetica-Oblique",
+        fontSize=9,
+        leading=12,
+        textColor=HexColor("#F57C00"),
+        backColor=HexColor("#FFF8E1"),
+        borderPadding=6,
+        spaceBefore=2,
+        spaceAfter=4,
+    )
+    style_tool = ParagraphStyle(
+        "ToolUse",
+        fontName="Helvetica",
+        fontSize=9,
+        leading=12,
+        textColor=HexColor("#7B1FA2"),
+        backColor=HexColor("#F3E5F5"),
+        borderPadding=6,
+        spaceBefore=4,
+        spaceAfter=4,
+    )
+    style_tool_result = ParagraphStyle(
+        "ToolResult",
+        fontName="Courier",
+        fontSize=8,
+        leading=10,
+        textColor=HexColor("#333333"),
+        backColor=HexColor("#D5ECD6"),
+        borderPadding=6,
+        spaceBefore=2,
+        spaceAfter=4,
+    )
+    style_code = ParagraphStyle(
+        "Code",
+        fontName="Courier",
+        fontSize=8,
+        leading=10,
+        textColor=HexColor("#E0E0E0"),
+        backColor=HexColor("#1E1E1E"),
+        borderPadding=6,
+        spaceBefore=4,
+        spaceAfter=4,
+    )
+    style_commit = ParagraphStyle(
+        "Commit",
+        fontName="Helvetica",
+        fontSize=9,
+        leading=12,
+        textColor=HexColor("#333333"),
+        spaceBefore=2,
+        spaceAfter=2,
+    )
+    style_tool_reply_role = ParagraphStyle(
+        "ToolReplyRole",
+        fontName="Helvetica-Bold",
+        fontSize=9,
+        textColor=HexColor("#4CAF50"),
+        spaceBefore=0,
+        spaceAfter=2,
+    )
+
+    # --- Build story ---
+    story = []
+
+    # Title
+    title_style = ParagraphStyle(
+        "Title",
+        fontName="Helvetica",
+        fontSize=24,
+        leading=30,
+        textColor=HexColor("#333333"),
+        spaceAfter=6,
+    )
+    story.append(Paragraph("Claude Code Transcript", title_style))
+
+    prompt_count, message_count = count_prompts_and_messages(conversations)
+    meta_style = ParagraphStyle(
+        "Meta", fontName="Helvetica", fontSize=10, textColor=HexColor("#999999")
+    )
+    story.append(
+        Paragraph(
+            f"{prompt_count} prompts &middot; {message_count} messages", meta_style
+        )
+    )
+    story.append(Spacer(1, 12))
+
+    for conv in conversations:
+        conv_elements = []
+        for log_type, message_json, timestamp in conv["messages"]:
+            message_data = json.loads(message_json)
+            content = message_data.get("content", "")
+            if not content:
+                continue
+
+            if log_type == "user":
+                if is_tool_result_message(message_data):
+                    # Build inner elements for the tool result box
+                    inner = []
+                    inner.append(
+                        Paragraph(
+                            f"<b>TOOL REPLY</b>  <font size=7 color='#757575'>{_escape(timestamp)}</font>",
+                            style_tool_reply_role,
+                        )
+                    )
+                    any_error = False
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        result_content = block.get("content", "")
+                        is_error = block.get("is_error", False)
+                        if is_error:
+                            any_error = True
+                        _add_tool_result(
+                            inner,
+                            result_content,
+                            is_error,
+                            github_repo,
+                            style_tool_result,
+                            style_commit,
+                            _escape,
+                            _truncate,
+                            COMMIT_PATTERN,
+                        )
+                    bg = "#FFEBEE" if any_error else "#D5ECD6"
+                    border = "#B71C1C" if any_error else "#4CAF50"
+                    conv_elements.extend(_wrap_in_colored_box(inner, bg, border))
+                else:
+                    conv_elements.append(
+                        Paragraph(
+                            f"<b>USER</b>  <font size=7 color='#757575'>{_escape(timestamp)}</font>",
+                            style_user_role,
+                        )
+                    )
+                    text = extract_text_from_content(content)
+                    if text:
+                        conv_elements.append(Paragraph(_escape(text), style_user_text))
+
+            elif log_type == "assistant":
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        block_type = block.get("type", "")
+
+                        if block_type == "text":
+                            text = block.get("text", "")
+                            if text:
+                                conv_elements.append(
+                                    Paragraph(
+                                        f"<b>ASSISTANT</b>  <font size=7 color='#757575'>{_escape(timestamp)}</font>",
+                                        style_assistant_role,
+                                    )
+                                )
+                                # Split into code blocks and text
+                                _add_markdown_content(
+                                    conv_elements,
+                                    text,
+                                    style_assistant_text,
+                                    style_code,
+                                    _escape,
+                                )
+
+                        elif block_type == "thinking":
+                            text = block.get("thinking", "")
+                            if text:
+                                short = _truncate(text, 500)
+                                conv_elements.append(
+                                    Paragraph(
+                                        f"<b><font color='#F57C00'>Thinking:</font></b> <i>{_escape(short)}</i>",
+                                        style_thinking,
+                                    )
+                                )
+
+                        elif block_type == "tool_use":
+                            tool_name = block.get("name", "Unknown")
+                            tool_input = block.get("input", {})
+                            _add_tool_use(
+                                conv_elements,
+                                tool_name,
+                                tool_input,
+                                style_tool,
+                                style_code,
+                                _escape,
+                                _truncate,
+                            )
+
+                        elif block_type == "image":
+                            _add_image_block(conv_elements, block)
+
+                        elif block_type == "tool_result":
+                            result_content = block.get("content", "")
+                            is_error = block.get("is_error", False)
+                            inner = []
+                            _add_tool_result(
+                                inner,
+                                result_content,
+                                is_error,
+                                github_repo,
+                                style_tool_result,
+                                style_commit,
+                                _escape,
+                                _truncate,
+                                COMMIT_PATTERN,
+                            )
+                            if inner:
+                                bg = "#FFEBEE" if is_error else "#D5ECD6"
+                                border = "#B71C1C" if is_error else "#4CAF50"
+                                conv_elements.extend(
+                                    _wrap_in_colored_box(inner, bg, border)
+                                )
+
+        if conv_elements:
+            story.extend(conv_elements)
+            story.append(Spacer(1, 6))
+
+    doc.build(story)
+
+
+def _markdown_to_xml(text, escape_fn):
+    """Convert basic markdown inline formatting to reportlab Paragraph XML.
+
+    Handles: **bold**, *italic*, `code`, [text](url), # headers.
+    Must be called on text that will go into a Paragraph (not Preformatted).
+    """
+    escaped = escape_fn(text)
+    # Bold: **text** or __text__
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", escaped)
+    escaped = re.sub(r"__(.+?)__", r"<b>\1</b>", escaped)
+    # Italic: *text* or _text_ (not inside words)
+    escaped = re.sub(r"(?<!\w)\*(.+?)\*(?!\w)", r"<i>\1</i>", escaped)
+    escaped = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"<i>\1</i>", escaped)
+    # Inline code: `code`
+    escaped = re.sub(
+        r"`([^`]+)`",
+        r"<font name='Courier' size=8 color='#C62828'>\1</font>",
+        escaped,
+    )
+    # Links: [text](url)
+    escaped = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        r"<a href='\2' color='#1976D2'><u>\1</u></a>",
+        escaped,
+    )
+    # Headers: # text → bold larger text
+    escaped = re.sub(
+        r"^(#{1,3})\s+(.+)$",
+        lambda m: f"<b><font size={14 - len(m.group(1))}>{m.group(2)}</font></b>",
+        escaped,
+        flags=re.MULTILINE,
+    )
+    return escaped
+
+
+def _add_markdown_content(elements, text, text_style, code_style, escape_fn):
+    """Add text with code blocks separated out, rendering markdown."""
+    from reportlab.platypus import Paragraph, Preformatted
+
+    lines = text.split("\n")
+    current_text = []
+    in_code = False
+    code_lines = []
+
+    def flush_text():
+        if current_text:
+            joined = "\n".join(current_text)
+            if joined.strip():
+                xml = _markdown_to_xml(joined, escape_fn)
+                elements.append(Paragraph(xml, text_style))
+            current_text.clear()
+
+    for line in lines:
+        if line.startswith("```"):
+            if in_code:
+                in_code = False
+                flush_text()
+                code_text = _wrap_long_lines("\n".join(code_lines))
+                if code_text.strip():
+                    elements.append(Preformatted(code_text, code_style))
+                code_lines.clear()
+            else:
+                in_code = True
+                flush_text()
+        elif in_code:
+            code_lines.append(line)
+        else:
+            current_text.append(line)
+
+    # Flush remaining
+    if in_code and code_lines:
+        elements.append(
+            Preformatted(_wrap_long_lines("\n".join(code_lines)), code_style)
+        )
+    flush_text()
+
+
+def _wrap_in_colored_box(inner_elements, bg_color, border_color=None):
+    """Wrap a list of flowables in colored Table(s) with optional left border.
+
+    Returns a list of flowables. The heading (first element) is placed in a
+    separate table with keepWithNext=True so it is never orphaned at the
+    bottom of a page without content following it.
+    """
+    from reportlab.platypus import Table, TableStyle
+    from reportlab.lib.colors import HexColor
+
+    def _make_table(elems, space_before=0, space_after=0, extra_top=6, extra_bottom=6):
+        data = [[e] for e in elems]
+        t = Table(data, colWidths=["*"])
+        n = len(data)
+        cmds = [
+            ("BACKGROUND", (0, 0), (-1, -1), HexColor(bg_color)),
+            ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+            ("LEFTPADDING", (0, 0), (-1, -1), 10),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+        ]
+        if n > 0:
+            cmds.append(("TOPPADDING", (0, 0), (-1, 0), extra_top))
+            cmds.append(("BOTTOMPADDING", (0, n - 1), (-1, n - 1), extra_bottom))
+        if border_color:
+            cmds.append(("LINEBEFORE", (0, 0), (0, -1), 3, HexColor(border_color)))
+        t.setStyle(TableStyle(cmds))
+        t.spaceBefore = space_before
+        t.spaceAfter = space_after
+        t.splitByRow = True
+        return t
+
+    return [_make_table(inner_elements, space_before=4, space_after=4)]
+
+
+def _add_tool_use(
+    elements, tool_name, tool_input, tool_style, code_style, escape_fn, truncate_fn
+):
+    """Add a tool use block wrapped in a purple container."""
+    from reportlab.platypus import Paragraph, Preformatted
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.lib.colors import HexColor
+
+    # Build inner elements for the tool use box
+    # Use plain styles (no background) since the container provides it
+    inner_tool_style = ParagraphStyle(
+        "ToolUseInner",
+        parent=tool_style,
+        backColor=None,
+        borderPadding=0,
+        spaceBefore=0,
+        spaceAfter=2,
+    )
+    # Table BACKGROUND paints over inner flowable backColor, so use
+    # dark text on the container's light purple instead of light-on-dark
+    inner_code_style = ParagraphStyle(
+        "ToolCodeInner",
+        parent=code_style,
+        backColor=None,
+        textColor=HexColor("#4A148C"),  # dark purple, readable on light purple
+        spaceBefore=2,
+        spaceAfter=2,
+        borderPadding=0,
+    )
+
+    inner = []
+    inner.append(Paragraph(f"<b>&#9881; {escape_fn(tool_name)}</b>", inner_tool_style))
+
+    if tool_name == "Write":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            inner.append(
+                Paragraph(
+                    f"<font name='Courier' size=8>&rarr; {escape_fn(file_path)}</font>",
+                    inner_tool_style,
+                )
+            )
+        content = tool_input.get("content", "")
+        if content:
+            inner.append(Preformatted(truncate_fn(content, 1000), inner_code_style))
+
+    elif tool_name == "Edit":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            inner.append(
+                Paragraph(
+                    f"<font name='Courier' size=8>&rarr; {escape_fn(file_path)}</font>",
+                    inner_tool_style,
+                )
+            )
+        old_str = tool_input.get("old_string", "")
+        new_str = tool_input.get("new_string", "")
+        if old_str:
+            del_style = ParagraphStyle(
+                "EditDel",
+                parent=inner_code_style,
+                textColor=HexColor("#B71C1C"),
+            )
+            inner.append(Preformatted("- " + truncate_fn(old_str, 500), del_style))
+        if new_str:
+            add_style = ParagraphStyle(
+                "EditAdd",
+                parent=inner_code_style,
+                textColor=HexColor("#1B5E20"),
+            )
+            inner.append(Preformatted("+ " + truncate_fn(new_str, 500), add_style))
+
+    elif tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if command:
+            inner.append(
+                Preformatted("$ " + truncate_fn(command, 500), inner_code_style)
+            )
+
+    else:
+        description = tool_input.get("description", "")
+        if description:
+            desc_style = ParagraphStyle(
+                "ToolDesc",
+                parent=inner_tool_style,
+                textColor=HexColor("#757575"),
+            )
+            inner.append(Paragraph(f"<i>{escape_fn(description)}</i>", desc_style))
+        display_input = {k: v for k, v in tool_input.items() if k != "description"}
+        if display_input:
+            input_text = json.dumps(display_input, indent=2, ensure_ascii=False)
+            inner.append(Preformatted(truncate_fn(input_text, 500), inner_code_style))
+
+    elements.extend(_wrap_in_colored_box(inner, "#F3E5F5", "#9C27B0"))
+
+
+_CHUNK_LINES = 20  # Split Preformatted into chunks of this many lines
+
+
+def _add_preformatted_chunks(elements, text, style):
+    """Add text as multiple Preformatted blocks so table rows can split."""
+    from reportlab.platypus import Preformatted
+
+    lines = text.split("\n")
+    if len(lines) <= _CHUNK_LINES:
+        elements.append(Preformatted(text, style))
+        return
+    for i in range(0, len(lines), _CHUNK_LINES):
+        chunk = "\n".join(lines[i : i + _CHUNK_LINES])
+        elements.append(Preformatted(chunk, style))
+
+
+def _add_tool_result(
+    elements,
+    result_content,
+    is_error,
+    github_repo,
+    result_style,
+    commit_style,
+    escape_fn,
+    truncate_fn,
+    commit_pattern,
+):
+    """Add a tool result block (content only, container handles background)."""
+    from reportlab.platypus import Paragraph, Preformatted
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.lib.colors import HexColor
+
+    # Use plain styles since the outer container provides background
+    plain_result = ParagraphStyle(
+        "ToolResultPlain",
+        parent=result_style,
+        backColor=None,
+        borderPadding=0,
+        spaceBefore=2,
+        spaceAfter=2,
+    )
+
+    if isinstance(result_content, str):
+        commits = list(commit_pattern.finditer(result_content))
+        if commits:
+            last_end = 0
+            for match in commits:
+                before = result_content[last_end : match.start()].strip()
+                if before:
+                    _add_preformatted_chunks(
+                        elements, truncate_fn(before, 1000), plain_result
+                    )
+                commit_hash = match.group(1)
+                commit_msg = match.group(2)
+                hash_display = escape_fn(commit_hash[:7])
+                if github_repo:
+                    link = f"https://github.com/{github_repo}/commit/{commit_hash}"
+                    hash_part = f"<a href='{link}' color='#E65100'><font name='Courier'><b>{hash_display}</b></font></a>"
+                else:
+                    hash_part = f"<font name='Courier' color='#E65100'><b>{hash_display}</b></font>"
+                elements.append(
+                    Paragraph(
+                        f"{hash_part} {escape_fn(commit_msg)}",
+                        commit_style,
+                    )
+                )
+                last_end = match.end()
+            after = result_content[last_end:].strip()
+            if after:
+                _add_preformatted_chunks(
+                    elements, truncate_fn(after, 1000), plain_result
+                )
+        else:
+            text = truncate_fn(result_content, 1000)
+            if text.strip():
+                if is_error:
+                    err_style = ParagraphStyle(
+                        "ErrorResult",
+                        parent=plain_result,
+                        textColor=HexColor("#B71C1C"),
+                    )
+                    _add_preformatted_chunks(elements, text, err_style)
+                else:
+                    _add_preformatted_chunks(elements, text, plain_result)
+    elif isinstance(result_content, list):
+        for item in result_content:
+            if isinstance(item, dict):
+                text = item.get("text", "")
+                if text:
+                    _add_preformatted_chunks(
+                        elements, truncate_fn(text, 1000), plain_result
+                    )
+
+
+def _add_image_block(elements, block):
+    """Add an image block placeholder."""
+    from reportlab.platypus import Paragraph
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.lib.colors import HexColor
+
+    img_style = ParagraphStyle(
+        "ImagePlaceholder",
+        fontName="Helvetica-Oblique",
+        fontSize=9,
+        textColor=HexColor("#999999"),
+    )
+    source_type = block.get("source", {}).get("type", "unknown")
+    elements.append(Paragraph(f"[Image: {source_type}]", img_style))

--- a/src/claude_code_transcripts/templates/single_page.html
+++ b/src/claude_code_transcripts/templates/single_page.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code transcript</title>
+    <style>{{ css|safe }}</style>
+    <style>
+    /* Print/PDF overrides - show all content expanded */
+    .truncatable .truncatable-content { max-height: none !important; overflow: visible !important; }
+    .truncatable::after { display: none !important; }
+    .expand-btn { display: none !important; }
+    .pagination { display: none !important; }
+    details.continuation { display: block; }
+    details.continuation > summary { display: none; }
+    #search-box { display: none !important; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Claude Code transcript</h1>
+        <p style="color: var(--text-muted); margin-bottom: 24px;">{{ prompt_count }} prompts &middot; {{ message_count }} messages</p>
+        {{ messages_html|safe }}
+    </div>
+</body>
+</html>

--- a/tests/test_docx_export.py
+++ b/tests/test_docx_export.py
@@ -1,0 +1,488 @@
+"""Tests for DOCX export functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_transcripts.docx_export import generate_docx
+
+
+@pytest.fixture
+def output_dir():
+    """Create a temporary output directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def sample_loglines():
+    return [
+        {
+            "type": "user",
+            "timestamp": "2025-01-01T10:00:00.000Z",
+            "message": {"role": "user", "content": "Hello, write a function"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2025-01-01T10:00:05.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Here is the function:\n```python\ndef hello():\n    print('hello')\n```",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2025-01-01T10:01:00.000Z",
+            "message": {"role": "user", "content": "Now add a parameter"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2025-01-01T10:01:05.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Updated:\n```python\ndef hello(name):\n    print(f'hello {name}')\n```",
+                    }
+                ],
+            },
+        },
+    ]
+
+
+class TestGenerateDocx:
+    """Tests for DOCX generation."""
+
+    def test_generates_docx_file_from_path(self, output_dir, sample_loglines):
+        """Test that generate_docx creates a DOCX file from a session file."""
+        session_file = output_dir / "test_session.json"
+        session_file.write_text(
+            json.dumps({"loglines": sample_loglines}), encoding="utf-8"
+        )
+
+        docx_path = output_dir / "output.docx"
+        generate_docx(session_file, docx_path)
+
+        assert docx_path.exists()
+        assert docx_path.stat().st_size > 0
+
+    def test_generates_docx_from_dict(self, output_dir, sample_loglines):
+        """Test that generate_docx accepts a dict with loglines."""
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        assert docx_path.exists()
+        assert docx_path.stat().st_size > 0
+
+    def test_docx_contains_user_messages(self, output_dir, sample_loglines):
+        """Test that the DOCX contains user message text."""
+        from docx import Document
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Hello, write a function" in full_text
+        assert "Now add a parameter" in full_text
+
+    def test_docx_contains_assistant_text(self, output_dir, sample_loglines):
+        """Test that the DOCX contains assistant response text."""
+        from docx import Document
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "def hello" in full_text
+
+    def test_docx_contains_title(self, output_dir, sample_loglines):
+        """Test that the DOCX has a title."""
+        from docx import Document
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        # Title should be in first paragraph (heading)
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Claude Code Transcript" in full_text
+
+    def test_docx_contains_stats(self, output_dir, sample_loglines):
+        """Test that the DOCX contains prompt/message counts."""
+        from docx import Document
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "2 prompts" in full_text
+        assert "4 messages" in full_text
+
+    def test_creates_parent_directories(self, output_dir, sample_loglines):
+        """Test that generate_docx creates parent directories."""
+        docx_path = output_dir / "subdir" / "nested" / "output.docx"
+        generate_docx({"loglines": sample_loglines}, docx_path)
+
+        assert docx_path.exists()
+
+    def test_docx_with_tool_use(self, output_dir):
+        """Test DOCX generation with tool use blocks."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Create a file"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Write",
+                            "id": "tool_1",
+                            "input": {
+                                "file_path": "/tmp/test.py",
+                                "content": "print('hello')",
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Write" in full_text
+        assert "/tmp/test.py" in full_text
+
+    def test_docx_with_image_block(self, output_dir):
+        """Test that generate_docx handles image blocks without crashing."""
+        # Valid 2x2 red PNG
+        red_pixel = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP8zwACTGCSAQANHQEDgslx/wAAAABJRU5ErkJggg=="
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Show me an image"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": red_pixel,
+                            },
+                        },
+                        {"type": "text", "text": "Here is the image."},
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        assert docx_path.exists()
+        assert docx_path.stat().st_size > 0
+
+    def test_docx_with_thinking_block(self, output_dir):
+        """Test that thinking blocks render in the DOCX."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Think about this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me consider the options carefully...",
+                        },
+                        {"type": "text", "text": "Here is my answer."},
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Thinking:" in full_text
+        assert "consider the options" in full_text
+        assert "Here is my answer" in full_text
+
+    def test_docx_with_generic_tool(self, output_dir):
+        """Test DOCX generation with a non-Write/Edit/Bash tool."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Search for something"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Grep",
+                            "id": "tool_1",
+                            "input": {
+                                "description": "Search for pattern",
+                                "pattern": "def hello",
+                                "path": "/src",
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Grep" in full_text
+        assert "Search for pattern" in full_text
+
+    def test_docx_with_commit_output(self, output_dir):
+        """Test DOCX renders commit hashes from tool results."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Commit this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "id": "tool_1",
+                            "input": {"command": "git commit -m 'test'"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": "[main abc1234] Add test feature\n 1 file changed",
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "abc1234" in full_text
+        assert "Add test feature" in full_text
+
+    def test_docx_with_error_tool_result(self, output_dir):
+        """Test DOCX renders error tool results."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Run this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "id": "tool_1",
+                            "input": {"command": "exit 1"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": "Error: command failed with exit code 1",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "command failed" in full_text
+
+    def test_docx_with_markdown_headers(self, output_dir):
+        """Test DOCX renders markdown headers as Word headings."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Explain this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "# Overview\nSome text\n## Details\nMore text\n### Subsection\nFinal text",
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Overview" in full_text
+        assert "Details" in full_text
+        assert "Subsection" in full_text
+
+    def test_docx_with_list_tool_result(self, output_dir):
+        """Test DOCX handles tool results that are lists of content blocks."""
+        from docx import Document
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Do something"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Read",
+                            "id": "tool_1",
+                            "input": {"file_path": "/tmp/test.py"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": [
+                                {"type": "text", "text": "Line 1 of file"},
+                                {"type": "text", "text": "Line 2 of file"},
+                            ],
+                        }
+                    ],
+                },
+            },
+        ]
+
+        docx_path = output_dir / "output.docx"
+        generate_docx({"loglines": loglines}, docx_path)
+
+        doc = Document(str(docx_path))
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Line 1 of file" in full_text
+        assert "Line 2 of file" in full_text
+
+    def test_docx_cli_format_option(self, output_dir):
+        """Test that --format docx option works via CLI."""
+        from click.testing import CliRunner
+        from claude_code_transcripts import cli
+
+        fixture_path = Path(__file__).parent / "sample_session.json"
+        docx_path = output_dir / "output.docx"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["json", str(fixture_path), "-o", str(docx_path), "--format", "docx"],
+        )
+
+        assert result.exit_code == 0
+        assert docx_path.exists()
+        assert "Output:" in result.output

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -27,6 +27,8 @@ from claude_code_transcripts import (
     parse_session_file,
     get_session_summary,
     find_local_sessions,
+    extract_conversations,
+    generate_single_page_html,
 )
 
 
@@ -1638,3 +1640,211 @@ class TestSearchFeature:
 
         # Total pages should be embedded for JS to know how many pages to fetch
         assert "totalPages" in index_html or "total_pages" in index_html
+
+
+class TestExtractConversations:
+    """Tests for extract_conversations function."""
+
+    def test_basic_extraction(self):
+        """Test extracting conversations from simple loglines."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Hi there!"}],
+                },
+            },
+        ]
+        convs = extract_conversations(loglines)
+        assert len(convs) == 1
+        assert convs[0]["user_text"] == "Hello"
+        assert convs[0]["timestamp"] == "2025-01-01T10:00:00.000Z"
+        assert len(convs[0]["messages"]) == 2
+        assert convs[0]["is_continuation"] is False
+
+    def test_multiple_conversations(self):
+        """Test extracting multiple conversations."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "First question"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "First answer"}],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:01:00.000Z",
+                "message": {"role": "user", "content": "Second question"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:01:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Second answer"}],
+                },
+            },
+        ]
+        convs = extract_conversations(loglines)
+        assert len(convs) == 2
+        assert convs[0]["user_text"] == "First question"
+        assert convs[1]["user_text"] == "Second question"
+
+    def test_continuation_flag(self):
+        """Test that isCompactSummary sets is_continuation."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Initial prompt"},
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T11:00:00.000Z",
+                "isCompactSummary": True,
+                "message": {"role": "user", "content": "Continuation summary"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        assert len(convs) == 2
+        assert convs[0]["is_continuation"] is False
+        assert convs[1]["is_continuation"] is True
+
+    def test_empty_loglines(self):
+        """Test with empty loglines."""
+        convs = extract_conversations([])
+        assert convs == []
+
+    def test_messages_are_json_strings(self):
+        """Test that messages are stored as (type, json_string, timestamp) tuples."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        log_type, message_json, timestamp = convs[0]["messages"][0]
+        assert log_type == "user"
+        assert isinstance(message_json, str)
+        parsed = json.loads(message_json)
+        assert parsed["content"] == "Hello"
+
+
+class TestGenerateSinglePageHtml:
+    """Tests for generate_single_page_html function."""
+
+    def test_renders_all_conversations(self):
+        """Test that all conversations are rendered in a single page."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "First question"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "First answer"}],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:01:00.000Z",
+                "message": {"role": "user", "content": "Second question"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:01:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Second answer"}],
+                },
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+        assert "First question" in html
+        assert "First answer" in html
+        assert "Second question" in html
+        assert "Second answer" in html
+
+    def test_no_pagination(self):
+        """Test that single page HTML has no pagination links."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+        assert "page-" not in html
+        assert "pagination" not in html.lower() or "display: none" in html
+
+    def test_no_javascript(self):
+        """Test that single page HTML has no JavaScript."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+        assert "<script>" not in html
+
+    def test_no_truncation(self):
+        """Test that truncation CSS is overridden."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+        assert "max-height: none" in html
+        assert "expand-btn" in html and "display: none" in html
+
+    def test_has_stats(self):
+        """Test that prompt and message counts are shown."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Hi!"}],
+                },
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+        assert "1 prompts" in html
+        assert "2 messages" in html

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -1,0 +1,479 @@
+"""Tests for PDF export functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_transcripts import (
+    extract_conversations,
+    generate_single_page_html,
+)
+
+try:
+    import reportlab
+
+    HAS_REPORTLAB = True
+except ImportError:
+    HAS_REPORTLAB = False
+
+
+@pytest.fixture
+def output_dir():
+    """Create a temporary output directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def sample_loglines():
+    return [
+        {
+            "type": "user",
+            "timestamp": "2025-01-01T10:00:00.000Z",
+            "message": {"role": "user", "content": "Hello, write a function"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2025-01-01T10:00:05.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Here is the function:\n```python\ndef hello():\n    print('hello')\n```",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2025-01-01T10:01:00.000Z",
+            "message": {"role": "user", "content": "Now add a parameter"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2025-01-01T10:01:05.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Updated:\n```python\ndef hello(name):\n    print(f'hello {name}')\n```",
+                    }
+                ],
+            },
+        },
+    ]
+
+
+@pytest.mark.skipif(
+    not HAS_REPORTLAB,
+    reason="reportlab not available",
+)
+class TestGeneratePdf:
+    """Tests for PDF generation."""
+
+    def test_generates_pdf_file_from_path(self, output_dir, sample_loglines):
+        """Test that generate_pdf creates a PDF file from a session file."""
+        from claude_code_transcripts import generate_pdf
+
+        session_file = output_dir / "test_session.json"
+        session_file.write_text(
+            json.dumps({"loglines": sample_loglines}), encoding="utf-8"
+        )
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf(session_file, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+        # PDF files start with %PDF
+        with open(pdf_path, "rb") as f:
+            assert f.read(4) == b"%PDF"
+
+    def test_generates_pdf_from_dict(self, output_dir, sample_loglines):
+        """Test that generate_pdf accepts a dict with loglines."""
+        from claude_code_transcripts import generate_pdf
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": sample_loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_creates_parent_directories(self, output_dir, sample_loglines):
+        """Test that generate_pdf creates parent directories."""
+        from claude_code_transcripts import generate_pdf
+
+        pdf_path = output_dir / "subdir" / "nested" / "output.pdf"
+        generate_pdf({"loglines": sample_loglines}, pdf_path)
+
+        assert pdf_path.exists()
+
+    def test_pdf_with_image_block(self, output_dir):
+        """Test that generate_pdf handles image blocks without crashing."""
+        from claude_code_transcripts import generate_pdf
+
+        # Valid 2x2 red PNG
+        red_pixel = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP8zwACTGCSAQANHQEDgslx/wAAAABJRU5ErkJggg=="
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Show me an image"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": red_pixel,
+                            },
+                        },
+                        {"type": "text", "text": "Here is the image."},
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_cli_format_option(self, output_dir):
+        """Test that --format pdf option works via CLI."""
+        from click.testing import CliRunner
+        from claude_code_transcripts import cli
+
+        fixture_path = Path(__file__).parent / "sample_session.json"
+        pdf_path = output_dir / "output.pdf"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["json", str(fixture_path), "-o", str(pdf_path), "--format", "pdf"],
+        )
+
+        assert result.exit_code == 0
+        assert pdf_path.exists()
+        assert "Output:" in result.output
+
+    def test_pdf_with_thinking_block(self, output_dir):
+        """Test that thinking blocks render in the PDF."""
+        from claude_code_transcripts import generate_pdf
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Think about this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me consider the options carefully...",
+                        },
+                        {"type": "text", "text": "Here is my answer."},
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_with_generic_tool(self, output_dir):
+        """Test PDF generation with a non-Write/Edit/Bash tool."""
+        from claude_code_transcripts import generate_pdf
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Search for something"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Grep",
+                            "id": "tool_1",
+                            "input": {
+                                "description": "Search for pattern",
+                                "pattern": "def hello",
+                                "path": "/src",
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_with_tool_result_in_assistant(self, output_dir):
+        """Test PDF handles tool_result blocks in assistant content."""
+        from claude_code_transcripts import generate_pdf
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Do something"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": [
+                                {"type": "text", "text": "Result output here"},
+                            ],
+                            "is_error": False,
+                        }
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_with_commit_output(self, output_dir):
+        """Test PDF renders commit hashes from tool results."""
+        from claude_code_transcripts import generate_pdf
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Commit this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "id": "tool_1",
+                            "input": {"command": "git commit -m 'test'"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": "[main abc1234] Add test feature\n 1 file changed",
+                        }
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_with_error_tool_result(self, output_dir):
+        """Test PDF renders error tool results with error styling."""
+        from claude_code_transcripts import generate_pdf
+
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Run this"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "id": "tool_1",
+                            "input": {"command": "exit 1"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": "Error: command failed with exit code 1",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+    def test_pdf_with_oversized_tool_result(self, output_dir):
+        """Test PDF handles tool results with many lines without crashing."""
+        from claude_code_transcripts import generate_pdf
+
+        # Create a tool result with 100+ lines that would overflow a page
+        long_output = "\n".join(f"line {i}: some output text" for i in range(120))
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "List files"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "id": "tool_1",
+                            "input": {"command": "find . -type f"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:10.000Z",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool_1",
+                            "content": long_output,
+                        }
+                    ],
+                },
+            },
+        ]
+
+        pdf_path = output_dir / "output.pdf"
+        generate_pdf({"loglines": loglines}, pdf_path)
+
+        assert pdf_path.exists()
+        assert pdf_path.stat().st_size > 0
+
+
+class TestPdfSinglePage:
+    """Tests for single-page HTML used by PDF (no reportlab needed)."""
+
+    def test_pdf_single_continuous_document(self):
+        """Test that the single page HTML has no pagination."""
+        loglines = [
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:00:00.000Z",
+                "message": {"role": "user", "content": "Hello, write a function"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2025-01-01T10:00:05.000Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Here is the function"}],
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2025-01-01T10:01:00.000Z",
+                "message": {"role": "user", "content": "Now add a parameter"},
+            },
+        ]
+        convs = extract_conversations(loglines)
+        html = generate_single_page_html(convs)
+
+        assert "Hello, write a function" in html
+        assert "Now add a parameter" in html
+        assert "page-001" not in html
+        assert "page-002" not in html
+
+
+class TestPdfGistIncompatibility:
+    """Test that --gist and --format pdf are incompatible."""
+
+    def test_gist_with_pdf_raises_error(self, output_dir):
+        """Test that --gist with --format pdf raises an error."""
+        from click.testing import CliRunner
+        from claude_code_transcripts import cli
+
+        fixture_path = Path(__file__).parent / "sample_session.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "json",
+                str(fixture_path),
+                "-o",
+                str(output_dir / "out.pdf"),
+                "--format",
+                "pdf",
+                "--gist",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "gist" in result.output.lower() or "HTML" in result.output


### PR DESCRIPTION
HTML and gists for sharing is great. But we're looking for a few options that can work with non-engineering tools inside enterprise walls for use in "Compound Engineering" review sessions at my company. 

- Add --format pdf and --format docx options
- Extract shared export helpers (extract_conversations, load_conversations, generate_single_page_html) into export_helpers.py
- New optional dependency groups: pip install claude-code-transcripts[pdf], [docx], or [export] for both

## Testing

Besides the automated tests (29 new for PDF/DOCX):

### Try PDF export
```bash
uv pip install -e '.[pdf]'
uv run claude-code-transcripts json tests/sample_session.json --format pdf
```

### Try DOCX export
```bash
uv pip install -e '.[docx]'
uv run claude-code-transcripts json tests/sample_session.json --format docx
```