### PR TITLE
Merge sessions across folders that share a display name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 uv.lock
 .playwright-mcp/
+claude-archive/

--- a/src/claude_code_transcripts/__init__.py
+++ b/src/claude_code_transcripts/__init__.py
@@ -269,19 +269,20 @@ def find_all_sessions(folder, include_agents=False):
         if summary.lower() == "warmup" or summary == "(no summary)":
             continue
 
-        # Get project folder
-        project_folder = session_file.parent
-        project_key = project_folder.name
+        # Group by display name so folders that resolve to the same project
+        # (e.g., C--projects-devjig and d--projects-devjig after a drive move)
+        # merge into a single entry instead of silently overwriting each other
+        # when the display name is later used as an output directory.
+        display_name = get_project_display_name(session_file.parent.name)
 
-        if project_key not in projects:
-            projects[project_key] = {
-                "name": get_project_display_name(project_key),
-                "path": project_folder,
+        if display_name not in projects:
+            projects[display_name] = {
+                "name": display_name,
                 "sessions": [],
             }
 
         stat = session_file.stat()
-        projects[project_key]["sessions"].append(
+        projects[display_name]["sessions"].append(
             {
                 "path": session_file,
                 "summary": summary,

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -163,6 +163,59 @@ class TestFindAllSessions:
             assert "summary" in session
             assert session["summary"] != "(no summary)"
 
+    def test_merges_folders_with_same_display_name(self, tmp_path):
+        """Folders whose display names collide must merge into one project.
+
+        Regression test: on Windows, the same logical project can appear under
+        multiple raw folder names (e.g., C--projects-devjig and d--projects-devjig
+        after a drive move). get_project_display_name collapses both to "devjig",
+        but the raw folder name was used as the dict key, creating duplicate
+        project entries that both wrote to the same output directory — silently
+        overwriting each other's index.html.
+        """
+        import os
+
+        # Both resolve to display name "merged" via get_project_display_name
+        folder_a = tmp_path / "-home-alice-projects-merged"
+        folder_b = tmp_path / "-mnt-c-Users-bob-projects-merged"
+        folder_a.mkdir(parents=True)
+        folder_b.mkdir(parents=True)
+
+        # Two sessions in each folder
+        sessions = [
+            (folder_a / "aaa.jsonl", "2025-01-01T10:00:00.000Z", "A1"),
+            (folder_a / "bbb.jsonl", "2025-01-03T10:00:00.000Z", "A2"),
+            (folder_b / "ccc.jsonl", "2025-01-02T10:00:00.000Z", "B1"),
+            (folder_b / "ddd.jsonl", "2025-01-04T10:00:00.000Z", "B2"),
+        ]
+        for path, ts, content in sessions:
+            path.write_text(
+                f'{{"type": "user", "timestamp": "{ts}", '
+                f'"message": {{"role": "user", "content": "{content}"}}}}\n'
+                f'{{"type": "assistant", "timestamp": "{ts}", '
+                f'"message": {{"role": "assistant", "content": '
+                f'[{{"type": "text", "text": "ok"}}]}}}}\n'
+            )
+
+        # Stagger file mtimes so sort assertions are deterministic
+        os.utime(folder_a / "aaa.jsonl", (1735725600, 1735725600))  # oldest
+        os.utime(folder_b / "ccc.jsonl", (1735812000, 1735812000))
+        os.utime(folder_a / "bbb.jsonl", (1735898400, 1735898400))
+        os.utime(folder_b / "ddd.jsonl", (1735984800, 1735984800))  # newest
+
+        result = find_all_sessions(tmp_path)
+
+        # Both source folders merge into a single "merged" project
+        assert len(result) == 1
+        assert result[0]["name"] == "merged"
+
+        # All four sessions are present, not just one folder's subset
+        assert len(result[0]["sessions"]) == 4
+
+        # Sessions from both source folders interleave correctly by mtime
+        names = [s["path"].name for s in result[0]["sessions"]]
+        assert names == ["ddd.jsonl", "bbb.jsonl", "ccc.jsonl", "aaa.jsonl"]
+
 
 class TestGenerateBatchHtml:
     """Tests for generate_batch_html function."""


### PR DESCRIPTION
On Windows, Claude Code session folders for the same logical project can appear under different drive-letter casings (e.g. `C--projects-devjig` and `d--projects-devjig` after a drive move). Previously the raw folder name was used as the dict key in `find_all_sessions()`, causing one folder to silently overwrite the other when `generate_batch_html` later derived the output directory from `get_project_display_name()`.

This PR groups sessions by display name directly, so both source folders merge into a single project entry with their sessions interleaved by mtime.

### What changed
- `find_all_sessions()` now keys `projects` by `get_project_display_name(folder.name)` rather than the raw folder name. The unused `path` field is removed from project entries (no callers read it — `session["path"]` is what's actually consumed downstream).
- New regression test `test_merges_folders_with_same_display_name` simulates two folders that resolve to the same display name with four sessions of staggered mtimes; asserts a single merged project with all four sessions in correct order.
- `.gitignore` adds `claude-archive/` (a local scratch dir convention; not strictly needed for this change but useful for contributors who archive past sessions locally — happy to drop if you'd rather keep it out).

### Tests
`uv run pytest` — all 123 tests pass, including the new one.